### PR TITLE
Support registry api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # DVote JS changelog
 
+## 0.21.0
+
+- Gateway API methods have been refactored to accomodate the Registry API
+    - `ApiName` and `ApiMethod` are available
+    - `GatewayApiName` and `GatewayApiMethod` are available
+    - `BackendApiName` and `BackendApiMethod` are available
+    - Renamed types and enum's
+        - `getGatewayInfo` is now `getInfo`
+        - `DVoteGatewayMethod` is now `GatewayApiMethod`
+        - `dvoteGatewayApiMethods` is now `gatewayApiMethods`
+        - New enum `backendApiMethods` (registry)
+        - `dvoteApis` is now `clientApis` (gateway and registry)
+            - `gatewayApis` and `backendApis` are also available
+        - `IDvoteRequestParameters` is now `IRequestParameters`
+
 ## 0.20.3
 
 - Using INewProcessParams in newProcess

--- a/example/bridge/index.ts
+++ b/example/bridge/index.ts
@@ -84,7 +84,7 @@ async function connectGateways(accounts: Account[]): Promise<GatewayPool | Gatew
     let gw: GatewayPool | Gateway
 
     if (config.dvoteGatewayUri && config.web3Uri) {
-        const info = new GatewayInfo(config.dvoteGatewayUri, ["census", "file", "info", "results", "vote"], config.web3Uri, config.dvoteGatewayPublicKey || "")
+        const info = new GatewayInfo(config.dvoteGatewayUri, ["census", "file", "results", "vote"], config.web3Uri, config.dvoteGatewayPublicKey || "")
         gw = await Gateway.fromInfo(info)
     }
     else {

--- a/example/index.ts
+++ b/example/index.ts
@@ -23,7 +23,7 @@ import { ProcessMetadata, ProcessMetadataTemplate } from "../src/models/process"
 import { GatewayInfo } from "../src/wrappers/gateway-info"
 import { SOKOL_CHAIN_ID, SOKOL_ENS_REGISTRY_ADDRESS, VOCHAIN_BLOCK_TIME } from "../src/constants"
 import { JsonSignature, BytesSignature } from "../src/util/data-signing"
-import { DVoteGatewayMethod } from "../src/models/gateway"
+import { DVoteGatewayMethod, RegistryApiMethod } from "../src/models/gateway"
 import { IGatewayDiscoveryParameters } from "../src/net/gateway-discovery"
 import { ProcessEnvelopeType, ProcessMode, ProcessStatus, ProcessCensusOrigin, ensHashAddress } from "../src/net/contracts"
 import { ContentHashedUri } from "../src/wrappers/content-hashed-uri"
@@ -723,6 +723,10 @@ async function gatewayRawRequest() {
     const req = { method: "getGatewayInfo" as DVoteGatewayMethod }  // Low level raw request
     const timeout = 5 * 1000
     const r = await pool.sendRequest(req, wallet, { timeout })
+    console.log("RESPONSE:", r)
+
+    const req2 = { method: "signUp" as RegistryApiMethod }  // Low level raw request
+    const r2 = await pool.sendRequest(req2, wallet, { timeout })
     console.log("RESPONSE:", r)
 
     // UNSIGNED

--- a/example/index.ts
+++ b/example/index.ts
@@ -23,7 +23,7 @@ import { ProcessMetadata, ProcessMetadataTemplate } from "../src/models/process"
 import { GatewayInfo } from "../src/wrappers/gateway-info"
 import { SOKOL_CHAIN_ID, SOKOL_ENS_REGISTRY_ADDRESS, VOCHAIN_BLOCK_TIME } from "../src/constants"
 import { JsonSignature, BytesSignature } from "../src/util/data-signing"
-import { DVoteGatewayMethod, RegistryApiMethod } from "../src/models/gateway"
+import { GatewayApiMethod, BackendApiMethod, ApiMethod } from "../src/models/gateway"
 import { IGatewayDiscoveryParameters } from "../src/net/gateway-discovery"
 import { ProcessEnvelopeType, ProcessMode, ProcessStatus, ProcessCensusOrigin, ensHashAddress } from "../src/net/contracts"
 import { ContentHashedUri } from "../src/wrappers/content-hashed-uri"
@@ -84,7 +84,7 @@ async function checkGatewayStatus() {
         // const gw = await Gateway.randomFromDefault(NETWORK_ID)
         const gw = await Gateway.randomfromUri(NETWORK_ID, BOOTNODES_URL_RO)
 
-        const status = await gw.getGatewayInfo()
+        const status = await gw.getInfo()
         console.log("Gateway status", status)
     }
     catch (err) {
@@ -720,12 +720,12 @@ async function gatewayRawRequest() {
     // SIGNED
     const wallet = Wallet.fromMnemonic(MNEMONIC, PATH)
 
-    const req = { method: "getGatewayInfo" as DVoteGatewayMethod }  // Low level raw request
+    const req = { method: "getInfo" as ApiMethod }  // Low level raw request
     const timeout = 5 * 1000
     const r = await pool.sendRequest(req, wallet, { timeout })
     console.log("RESPONSE:", r)
 
-    const req2 = { method: "signUp" as RegistryApiMethod }  // Low level raw request
+    const req2 = { method: "signUp" as BackendApiMethod }  // Low level raw request
     const r2 = await pool.sendRequest(req2, wallet, { timeout })
     console.log("RESPONSE:", r)
 

--- a/src/api/census.ts
+++ b/src/api/census.ts
@@ -1,6 +1,6 @@
 import { Wallet, Signer, providers, BigNumber, ContractReceipt } from "ethers"
 import { Gateway, IGateway } from "../net/gateway"
-import { IDvoteRequestParameters } from "../net/gateway-dvote"
+import { IRequestParameters } from "../net/gateway-dvote"
 import { IGatewayPool, GatewayPool } from "../net/gateway-pool"
 import { sha3_256 } from 'js-sha3'
 import { hashBuffer } from "../util/hashing"
@@ -221,7 +221,7 @@ export class CensusOffChainApi {
         if (!censusId || !gateway) return Promise.reject(new Error("Invalid parameters"))
         else if (!(gateway instanceof Gateway || gateway instanceof GatewayPool)) return Promise.reject(new Error("Invalid Gateway object"))
 
-        const msg: IDvoteRequestParameters = (rootHash) ? { method: "dump", censusId, rootHash } : { method: "dump", censusId }
+        const msg: IRequestParameters = (rootHash) ? { method: "dump", censusId, rootHash } : { method: "dump", censusId }
 
         return gateway.sendRequest(msg, walletOrSigner)
             .then(response => {
@@ -243,7 +243,7 @@ export class CensusOffChainApi {
         if (!censusId || !gateway) return Promise.reject(new Error("Invalid parameters"))
         else if (!(gateway instanceof Gateway || gateway instanceof GatewayPool)) return Promise.reject(new Error("Invalid Gateway object"))
 
-        const msg: IDvoteRequestParameters = (rootHash) ? { method: "dumpPlain", censusId, rootHash } : { method: "dumpPlain", censusId }
+        const msg: IRequestParameters = (rootHash) ? { method: "dumpPlain", censusId, rootHash } : { method: "dumpPlain", censusId }
 
         return gateway.sendRequest(msg, walletOrSigner)
             .then(response => {

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -1,7 +1,7 @@
 import { ContentUri } from "../wrappers/content-uri"
 import { ContentHashedUri } from "../wrappers/content-hashed-uri"
 import { Gateway, IGateway } from "../net/gateway"
-import { DVoteGateway, IDVoteGateway, IDvoteRequestParameters } from "../net/gateway-dvote"
+import { DVoteGateway, IDVoteGateway, IRequestParameters } from "../net/gateway-dvote"
 import { IGatewayPool, GatewayPool } from "../net/gateway-pool"
 import { IPFS } from "../net/ipfs"
 import { Buffer } from 'buffer/'
@@ -152,7 +152,7 @@ export class FileApi {
             buffer = new Uint8Array(Buffer.from(buffer))
         }
 
-        const requestBody: IDvoteRequestParameters = {
+        const requestBody: IRequestParameters = {
             method: "addFile",
             type: "ipfs",
             name,

--- a/src/models/gateway.ts
+++ b/src/models/gateway.ts
@@ -6,6 +6,7 @@ export type CensusApiMethod = "addCensus" | "addClaim" | "addClaimBulk" | "getRo
 export type ResultsApiMethod = "getProcListResults" | "getProcListLiveResults" | "getResults" | "getScrutinizerEntities"
 export type InfoApiMethod = "getGatewayInfo"
 export type DVoteGatewayMethod = FileApiMethod | VoteApiMethod | CensusApiMethod | ResultsApiMethod | InfoApiMethod
+export type RegistryApiMethod = "signUp" | "getEntity" | "updateEntity" | "countMembers" | "listMembers" | "getMember" | "updateMember" | "deleteMembers" | "generateTokens" | "exportTokens" | "importMembers" | "countTargets" | "listTargets" | "getTarget" | "dumpTarget" | "dumpCensus" | "addCensus" | "updateCensus" | "getCensus" | "countCensus" | "listCensus" | "deleteCensus" | "sendValidationLinks" | "sendVotingLinks" | "createTag" | "listTags" | "deleteTag" | "addTag" | "removeTag"
 
 export const fileApiMethods: FileApiMethod[] = ["fetchFile", "addFile", "pinList", "pinFile", "unpinFile"]
 export const voteApiMethods: VoteApiMethod[] = ["submitEnvelope", "getEnvelopeStatus", "getEnvelope", "getEnvelopeHeight", "getProcessKeys", "getProcessList", "getEnvelopeList", "getBlockHeight", "getBlockStatus", "getResults"]
@@ -20,6 +21,7 @@ export const dvoteApis: { [k in DVoteSupportedApi]: DVoteGatewayMethod[] } = {
     "results": resultsApiMethods,
     "info": infoApiMethods,
 }
+export const registryApiMethods: RegistryApiMethod[] = ["signUp", "getEntity", "updateEntity", "countMembers", "listMembers", "getMember", "updateMember", "deleteMembers", "generateTokens", "exportTokens", "importMembers", "countTargets", "listTargets", "getTarget", "dumpTarget", "dumpCensus", "addCensus", "updateCensus", "getCensus", "countCensus", "listCensus", "deleteCensus", "sendValidationLinks", "sendVotingLinks", "createTag", "listTags", "deleteTag", "addTag", "removeTag"]
 
 export type JsonBootnodeData = {
     [k: string]: {

--- a/src/models/gateway.ts
+++ b/src/models/gateway.ts
@@ -1,31 +1,53 @@
-export type DVoteSupportedApi = "file" | "vote" | "census" | "results" | "info"
+// API names
+export type GatewayApiName = "file" | "vote" | "census" | "results"
+export type BackendApiName = "registry"
+export type ApiName = GatewayApiName | BackendApiName | "info"
 
+const GET_INFO_METHOD_NAME = "getInfo"
+
+// API method families
 export type FileApiMethod = "fetchFile" | "addFile" | "pinList" | "pinFile" | "unpinFile"
 export type VoteApiMethod = "submitEnvelope" | "getEnvelopeStatus" | "getEnvelope" | "getEnvelopeHeight" | "getProcessKeys" | "getProcessList" | "getEnvelopeList" | "getBlockHeight" | "getBlockStatus" | "getResults"
 export type CensusApiMethod = "addCensus" | "addClaim" | "addClaimBulk" | "getRoot" | "genProof" | "getSize" | "checkProof" | "dump" | "dumpPlain" | "importDump" | "publish" | "importRemote"
 export type ResultsApiMethod = "getProcListResults" | "getProcListLiveResults" | "getResults" | "getScrutinizerEntities"
-export type InfoApiMethod = "getGatewayInfo"
-export type DVoteGatewayMethod = FileApiMethod | VoteApiMethod | CensusApiMethod | ResultsApiMethod | InfoApiMethod
+
 export type RegistryApiMethod = "signUp" | "getEntity" | "updateEntity" | "countMembers" | "listMembers" | "getMember" | "updateMember" | "deleteMembers" | "generateTokens" | "exportTokens" | "importMembers" | "countTargets" | "listTargets" | "getTarget" | "dumpTarget" | "dumpCensus" | "addCensus" | "updateCensus" | "getCensus" | "countCensus" | "listCensus" | "deleteCensus" | "sendValidationLinks" | "sendVotingLinks" | "createTag" | "listTags" | "deleteTag" | "addTag" | "removeTag"
 
+export type InfoApiMethod = typeof GET_INFO_METHOD_NAME
+
+export type GatewayApiMethod = FileApiMethod | VoteApiMethod | CensusApiMethod | ResultsApiMethod
+export type BackendApiMethod = RegistryApiMethod
+export type ApiMethod = GatewayApiMethod | BackendApiMethod | InfoApiMethod
+
+// API method enum's
 export const fileApiMethods: FileApiMethod[] = ["fetchFile", "addFile", "pinList", "pinFile", "unpinFile"]
 export const voteApiMethods: VoteApiMethod[] = ["submitEnvelope", "getEnvelopeStatus", "getEnvelope", "getEnvelopeHeight", "getProcessKeys", "getProcessList", "getEnvelopeList", "getBlockHeight", "getBlockStatus", "getResults"]
 export const censusApiMethods: CensusApiMethod[] = ["addCensus", "addClaim", "addClaimBulk", "getRoot", "genProof", "getSize", "checkProof", "dump", "dumpPlain", "importDump", "publish", "importRemote"]
 export const resultsApiMethods: ResultsApiMethod[] = ["getProcListResults", "getProcListLiveResults", "getResults", "getScrutinizerEntities"]
-export const infoApiMethods: InfoApiMethod[] = ["getGatewayInfo"]
-export const dvoteGatewayApiMethods: (FileApiMethod | VoteApiMethod | CensusApiMethod | ResultsApiMethod | InfoApiMethod)[] = [].concat(fileApiMethods).concat(voteApiMethods).concat(censusApiMethods).concat(resultsApiMethods).concat(infoApiMethods)
-export const dvoteApis: { [k in DVoteSupportedApi]: DVoteGatewayMethod[] } = {
-    "file": fileApiMethods,
-    "vote": voteApiMethods,
-    "census": censusApiMethods,
-    "results": resultsApiMethods,
-    "info": infoApiMethods,
-}
+
 export const registryApiMethods: RegistryApiMethod[] = ["signUp", "getEntity", "updateEntity", "countMembers", "listMembers", "getMember", "updateMember", "deleteMembers", "generateTokens", "exportTokens", "importMembers", "countTargets", "listTargets", "getTarget", "dumpTarget", "dumpCensus", "addCensus", "updateCensus", "getCensus", "countCensus", "listCensus", "deleteCensus", "sendValidationLinks", "sendVotingLinks", "createTag", "listTags", "deleteTag", "addTag", "removeTag"]
+
+export const gatewayApiMethods: GatewayApiMethod[] = [].concat(fileApiMethods).concat(voteApiMethods).concat(censusApiMethods).concat(resultsApiMethods)
+export const backendApiMethods: RegistryApiMethod[] = [].concat(registryApiMethods)
+
+// API methods per family
+export const allApis: { [k in ApiName]: ApiMethod[] } = {
+    // Gateway
+    file: fileApiMethods,
+    vote: voteApiMethods,
+    census: censusApiMethods,
+    results: resultsApiMethods,
+
+    // Backend
+    registry: registryApiMethods,
+
+    // Info
+    info: [GET_INFO_METHOD_NAME],
+}
 
 export type JsonBootnodeData = {
     [k: string]: {
         web3: { uri: string }[],
-        dvote: { uri: string, apis: DVoteSupportedApi[], pubKey: string }[]
+        dvote: { uri: string, apis: (GatewayApiName | BackendApiName)[], pubKey: string }[]
     }
 }

--- a/src/net/gateway-discovery.ts
+++ b/src/net/gateway-discovery.ts
@@ -59,7 +59,7 @@ export class GatewayDiscovery {
  * basic rounds
  * 1. Check sets of gateways: The retrieved list of gateways is randomized and split in
  *    sets of $ParallelGatewayTests that are pararrely checked (respond in /ping and
- *     getGatewayInfo) with a time limit of $GATEWAY_SELECTION_TIMEOUT
+ *     getInfo) with a time limit of $GATEWAY_SELECTION_TIMEOUT
  * 2. Repeat 1 wiht timeout backtracking: Currently simply using 2*$GATEWAY_SELECTION_TIMEOUT
  * @param networkId The Ethereum network to which the gateway should be associated
  * @param bootnodesContentUri (optional) The Content URI from which the list of gateways will be extracted
@@ -215,7 +215,7 @@ function arrangePairedNodes(dvoteGateways: IDVoteGateway[], web3Gateways: IWeb3G
 
 /**
  * Implements the health check on the gateways pararrely checkig in /ping and
- * getGatewayInfo with a time limit of timeout.
+ * getInfo with a time limit of timeout.
  * Also the Web3Gateways are mapped to coresponding DvoteGateways in case the
  * should be chosen in a coupled manner
  * @param dvoteNodes The set of DvoteGateways to be checked

--- a/src/net/gateway-dvote.ts
+++ b/src/net/gateway-dvote.ts
@@ -2,7 +2,7 @@ import { parseURL } from 'universal-parse-url'
 import { Buffer } from 'buffer/'
 import { Wallet, Signer } from "ethers"
 import { GatewayInfo } from "../wrappers/gateway-info"
-import { DVoteSupportedApi, DVoteGatewayMethod, RegistryApiMethod, dvoteApis, registryApiMethods } from "../models/gateway"
+import { GatewayApiMethod, BackendApiMethod, allApis, registryApiMethods, ApiMethod, GatewayApiName, BackendApiName, InfoApiMethod } from "../models/gateway"
 import { GATEWAY_SELECTION_TIMEOUT } from "../constants"
 import { JsonSignature, BytesSignature } from "../util/data-signing"
 import axios, { AxiosInstance, AxiosResponse } from "axios"
@@ -21,9 +21,9 @@ export type IDVoteGateway = InstanceType<typeof DVoteGateway>
 
 
 /** Parameters sent by the function caller */
-export interface IDvoteRequestParameters {
+export interface IRequestParameters {
     // Common
-    method: DVoteGatewayMethod | RegistryApiMethod,
+    method: ApiMethod,
     timestamp?: number,
 
     [k: string]: any
@@ -32,7 +32,7 @@ export interface IDvoteRequestParameters {
 /** What is actually sent by sendRequest() to the Gateway */
 type MessageRequestContent = {
     id: string,
-    request: IDvoteRequestParameters,
+    request: IRequestParameters,
     signature?: string
 }
 
@@ -57,7 +57,7 @@ type DVoteGatewayResponse = {
  * intended to interact within voting processes
  */
 export class DVoteGateway {
-    private _supportedApis: DVoteSupportedApi[] = []
+    private _supportedApis: (GatewayApiName | BackendApiName)[] = []
     private _pubKey: string = ""
     private _health: number = 0
     private _uri: string
@@ -67,7 +67,7 @@ export class DVoteGateway {
      * Returns a new DVote Gateway web socket client
      * @param gatewayOrParams Either a GatewayInfo instance or a JSON object with the service URI, the supported API's and the public key
      */
-    constructor(gatewayOrParams: GatewayInfo | { uri: string, supportedApis: DVoteSupportedApi[], publicKey?: string }) {
+    constructor(gatewayOrParams: GatewayInfo | { uri: string, supportedApis: (GatewayApiName | BackendApiName)[], publicKey?: string }) {
         if (gatewayOrParams instanceof GatewayInfo) {
             this.client = axios.create({ baseURL: gatewayOrParams.dvote, method: "post" })
             this._uri = gatewayOrParams.dvote
@@ -85,7 +85,7 @@ export class DVoteGateway {
     }
 
     /** Checks the gateway status and updates the currently available API's. Same as calling `isUp()` */
-    public init(requiredApis: DVoteSupportedApi[] = []): Promise<void> {
+    public init(requiredApis: (GatewayApiName | BackendApiName)[] = []): Promise<void> {
         return this.isUp().then(() => {
             if (!this.supportedApis) return
             else if (!requiredApis.length) return
@@ -112,7 +112,7 @@ export class DVoteGateway {
      * @param wallet (optional) The wallet to use for signing (default: null)
      * @param params (optional) Optional parameters. Timeout in milliseconds.
      */
-    public async sendRequest(requestBody: IDvoteRequestParameters, wallet: Wallet | Signer = null, params: { timeout?: number } = { timeout: 15 * 1000 }): Promise<DVoteGatewayResponseBody> {
+    public async sendRequest(requestBody: IRequestParameters, wallet: Wallet | Signer = null, params: { timeout?: number } = { timeout: 15 * 1000 }): Promise<DVoteGatewayResponseBody> {
         if (!this.isReady) throw new Error("Not initialized")
         else if (typeof requestBody != "object") throw new Error("The payload should be a javascript object")
         else if (typeof wallet != "object") throw new Error("The wallet is required")
@@ -243,7 +243,7 @@ export class DVoteGateway {
 
     /** Retrieves the status of the gateway and updates the internal status */
     public updateGatewayStatus(timeout?: number): Promise<any> {
-        return this.getGatewayInfo(timeout)
+        return this.getInfo(timeout)
             .then((result) => {
                 if (!result) throw new Error("Could not update")
                 else if (!Array.isArray(result.apiList)) throw new Error("apiList is not an array")
@@ -257,12 +257,12 @@ export class DVoteGateway {
      * Retrieves the status of the given gateway and returns an object indicating the services it provides.
      * If there is no connection open, the method returns null.
      */
-    public async getGatewayInfo(timeout?: number): Promise<{ apiList: DVoteSupportedApi[], health: number }> {
+    public async getInfo(timeout?: number): Promise<{ apiList: (GatewayApiName | BackendApiName)[], health: number }> {
         if (!this.isReady) return null
 
         try {
             const result = await promiseWithTimeout(
-                this.sendRequest({ method: "getGatewayInfo" }, null),
+                this.sendRequest({ method: "getInfo" }, null),
                 timeout || 1000
             )
             if (!Array.isArray(result.apiList)) throw new Error("apiList is not an array")
@@ -298,19 +298,20 @@ export class DVoteGateway {
      * Determines whether the current DVote Gateway supports the API set that includes the given method.
      * NOTE: `updateStatus()` must have been called on the GW instnace previously.
      */
-    public supportsMethod(method: DVoteGatewayMethod | RegistryApiMethod): boolean {
-        if (dvoteApis.file.includes(method as DVoteGatewayMethod))
+    public supportsMethod(method: ApiMethod): boolean {
+        if (allApis.info.includes(method as InfoApiMethod)) return true
+        // Gateway
+        else if (allApis.file.includes(method as GatewayApiMethod))
             return this.supportedApis.includes("file")
-        else if (dvoteApis.census.includes(method as DVoteGatewayMethod))
+        else if (allApis.census.includes(method as GatewayApiMethod))
             return this.supportedApis.includes("census")
-        else if (dvoteApis.vote.includes(method as DVoteGatewayMethod))
+        else if (allApis.vote.includes(method as GatewayApiMethod))
             return this.supportedApis.includes("vote")
-        else if (dvoteApis.results.includes(method as DVoteGatewayMethod))
+        else if (allApis.results.includes(method as GatewayApiMethod))
             return this.supportedApis.includes("results")
-        else if (dvoteApis.info.includes(method as DVoteGatewayMethod)) return true
-
-        // In the case of registry methods, we can't know explicitly => accept
-        else if (registryApiMethods.includes(method as RegistryApiMethod)) return true
+        // Registry
+        else if (allApis.registry.includes(method as BackendApiMethod))
+            return this.supportedApis.includes("registry")
         return false
     }
 }

--- a/src/net/gateway-pool.ts
+++ b/src/net/gateway-pool.ts
@@ -1,6 +1,6 @@
 import { Gateway } from "./gateway"
-import { DVoteGatewayResponseBody, IDvoteRequestParameters } from "./gateway-dvote"
-// import { dvoteApis, DVoteSupportedApi } from "../models/gateway"
+import { DVoteGatewayResponseBody, IRequestParameters } from "./gateway-dvote"
+// import { clientApis, GatewayApiName } from "../models/gateway"
 import { GatewayDiscovery, IGatewayDiscoveryParameters } from "./gateway-discovery"
 import { Wallet, Signer, providers } from "ethers"
 import { IProcessContract, IEnsPublicResolverContract, INamespaceContract, ITokenStorageProofContract } from "./contracts"
@@ -94,7 +94,7 @@ export class GatewayPool {
         return this.activeGateway.dvoteUri
     }
 
-    public sendRequest(requestBody: IDvoteRequestParameters, wallet: Wallet | Signer = null, params?: { timeout: number }): Promise<DVoteGatewayResponseBody> {
+    public sendRequest(requestBody: IRequestParameters, wallet: Wallet | Signer = null, params?: { timeout: number }): Promise<DVoteGatewayResponseBody> {
         if (!this.activeGateway.supportsMethod(requestBody.method)) {
             this.errorCount += 1
             return this.shift()

--- a/src/net/gateway.ts
+++ b/src/net/gateway.ts
@@ -4,7 +4,7 @@
 
 import { Contract, providers, utils, Wallet, Signer } from "ethers"
 import { GatewayInfo } from "../wrappers/gateway-info"
-import { DVoteSupportedApi, DVoteGatewayMethod } from "../models/gateway"
+import { DVoteSupportedApi, DVoteGatewayMethod, RegistryApiMethod } from "../models/gateway"
 import { GatewayBootnode, EthNetworkID } from "./gateway-bootnode"
 import { ContentUri } from "../wrappers/content-uri"
 import { IProcessContract, IEnsPublicResolverContract, INamespaceContract, ITokenStorageProofContract } from "../net/contracts"
@@ -167,7 +167,7 @@ export class Gateway {
         return this.dvote.getGatewayInfo(timeout)
     }
 
-    public supportsMethod(method: DVoteGatewayMethod): boolean {
+    public supportsMethod(method: DVoteGatewayMethod | RegistryApiMethod): boolean {
         return this.dvote.supportsMethod(method)
     }
 

--- a/src/wrappers/gateway-info.ts
+++ b/src/wrappers/gateway-info.ts
@@ -1,10 +1,10 @@
-import { DVoteSupportedApi } from "../models/gateway"
+import { GatewayApiName } from "../models/gateway"
 
 // const uriPattern = /^([a-z][a-z0-9+.-]+):(\/\/([^@]+@)?([a-z0-9.\-_~]+)(:\d+)?)?((?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@])+(?:\/(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@])*)*|(?:\/(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@])+)*)?(\?(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@]|[/?])+)?(\#(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@]|[/?])+)?$/i
 
 export class GatewayInfo {
     private dvoteUri: string
-    private supportedApiList: DVoteSupportedApi[]
+    private supportedApiList: GatewayApiName[]
     private web3Uri: string
     private pubKey: string
 
@@ -14,7 +14,7 @@ export class GatewayInfo {
     public get publicKey() { return this.pubKey }
 
     /** Bundles the given coordinates into an object containing the details of a Gateway */
-    constructor(dvoteUri: string = null, supportedApis: DVoteSupportedApi[] = [], web3Uri: string, pubKey?: string) {
+    constructor(dvoteUri: string = null, supportedApis: GatewayApiName[] = [], web3Uri: string, pubKey?: string) {
         if (!dvoteUri && !web3Uri) throw new Error("DVote URI or Web3 URI is required")
 
         if (dvoteUri) {

--- a/test/helpers/all-services.ts
+++ b/test/helpers/all-services.ts
@@ -34,7 +34,7 @@ export default class DevServices {
     }
 
     get gatewayInfo() {
-        return new GatewayInfo(this.dvote.uri, ["file", "vote", "census", "results", "info"], this.web3.uri, this.dvote.publicKey)
+        return new GatewayInfo(this.dvote.uri, ["file", "vote", "census", "results"], this.web3.uri, this.dvote.publicKey)
     }
 
     /** Returns a Gateway client for the dvote and Web3 local services. The Web3 gateway uses the given addresses as the resolved ones for the contracts */

--- a/test/helpers/dvote-service.ts
+++ b/test/helpers/dvote-service.ts
@@ -7,6 +7,7 @@ import { JsonSignature } from "../../src/util/data-signing"
 import { DVoteGateway } from "../../src/net/gateway-dvote"
 import { GatewayInfo } from "../../src/wrappers/gateway-info"
 import { getWallets } from "./web3-service"
+import { BackendApiName, GatewayApiName } from "../../src/models/gateway";
 
 
 export type TestResponse = {
@@ -26,7 +27,7 @@ export type MockedInteraction = {
 }
 
 const defaultPort = 8500
-const defaultConnectResponse: TestResponseBody = { ok: true, apiList: ["file", "vote", "census", "results", "info"], health: 100 }
+const defaultConnectResponse: TestResponseBody = { ok: true, apiList: ["file", "vote", "census", "results"], health: 100 } as { ok: boolean, apiList: (GatewayApiName | BackendApiName)[], health: number }
 
 // THE GATEWAY SERVER MOCK
 
@@ -117,9 +118,9 @@ export class DevGatewayService {
     get privateKey() { return this.wallet.privateKey }
     get publicKey() { return this.wallet["_signingKey"]().compressedPublicKey }
     get client() {
-        return new DVoteGateway({ uri: this.uri, supportedApis: ["file", "census", "vote", "results", "info"], publicKey: this.publicKey })
+        return new DVoteGateway({ uri: this.uri, supportedApis: ["file", "census", "vote", "results"], publicKey: this.publicKey })
     }
     get gatewayInfo() {
-        return new GatewayInfo(this.uri, ["file", "vote", "census", "results", "info"], "http://dummy", this.publicKey)
+        return new GatewayInfo(this.uri, ["file", "vote", "census", "results"], "http://dummy", this.publicKey)
     }
 }

--- a/test/integration/block-numbers.ts
+++ b/test/integration/block-numbers.ts
@@ -8,12 +8,13 @@ import { VotingApi } from "../../src/api/voting"
 import { DevGatewayService, MockedInteraction, TestResponse } from "../helpers/dvote-service"
 import { DevWeb3Service } from "../helpers/web3-service"
 import { VOCHAIN_BLOCK_TIME } from "../../src/constants"
+import { BackendApiName, GatewayApiName } from "../../src/models/gateway"
 
 const dvotePort = 8500
 const web3Port = 8600
 const web3DummyService = new DevWeb3Service({ port: web3Port })
 
-const defaultConnectResponse = { timestamp: 123, ok: true, apiList: ["file", "vote", "census", "results", "info"], health: 100 }
+const defaultConnectResponse = { timestamp: 123, ok: true, apiList: ["file", "vote", "census", "results"], health: 100 } as { ok: boolean, apiList: (GatewayApiName | BackendApiName)[], health: number }
 
 addCompletionHooks()
 

--- a/test/integration/gateway.ts
+++ b/test/integration/gateway.ts
@@ -9,6 +9,7 @@ import { DevGatewayService } from "../helpers/dvote-service"
 import { DevWeb3Service, getWallets } from "../helpers/web3-service"
 import { Buffer } from "buffer/"
 import { GatewayInfo } from "../../src/wrappers/gateway-info"
+import { BackendApiName, GatewayApiName } from "../../src/models/gateway"
 
 // let accounts: TestAccount[]
 let baseAccount = new DevWeb3Service({ port: 80000 }).accounts[0]
@@ -16,7 +17,7 @@ let baseAccount = new DevWeb3Service({ port: 80000 }).accounts[0]
 // let randomAccount: TestAccount
 let port: number = 9100
 
-const defaultConnectResponse = { timestamp: 123, ok: true, apiList: ["file", "vote", "census", "results", "info"], health: 100 }
+const defaultConnectResponse = { timestamp: 123, ok: true, apiList: ["file", "vote", "census", "results"], health: 100 } as { ok: boolean, apiList: (GatewayApiName | BackendApiName)[], health: number }
 const defaultDummyResponse = { ok: true }
 
 addCompletionHooks()


### PR DESCRIPTION
This PR allows to use DVoteGateway clients transparently targeting both gateway and backend endpoints

- Gateway API methods have been refactored to accomodate the Registry API
    - `ApiName` and `ApiMethod` are available
    - `GatewayApiName` and `GatewayApiMethod` are available
    - `BackendApiName` and `BackendApiMethod` are available
    - Renamed types and enum's
        - `getGatewayInfo` is now `getInfo`
        - `DVoteGatewayMethod` is now `GatewayApiMethod`
        - `dvoteGatewayApiMethods` is now `gatewayApiMethods`
        - New enum `backendApiMethods` (registry)
        - `dvoteApis` is now `clientApis` (gateway and registry)
            - `gatewayApis` and `backendApis` are also available
        - `IDvoteRequestParameters` is now `IRequestParameters`
