### PR TITLE
Using compressed public keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
         - `dvoteApis` is now `clientApis` (gateway and registry)
             - `gatewayApis` and `backendApis` are also available
         - `IDvoteRequestParameters` is now `IRequestParameters`
+- Using compressed keys everywhere
+    - Adding `compressPublicKey` and `expandPublicKey`
+    - `digestHexClaim` is now `digestPublicKey`
+    - `digestPublicKey` compresses all keys
 
 ## 0.20.3
 

--- a/example/bridge/index.ts
+++ b/example/bridge/index.ts
@@ -13,7 +13,8 @@ import {
     EntityMetadataTemplate,
     ProcessMetadata, ProcessMetadataTemplate,
     ProcessContractParameters, ProcessMode, ProcessEnvelopeType, ProcessStatus, IProcessCreateParams, ProcessCensusOrigin,
-    VochainWaiter, EthWaiter
+    VochainWaiter, EthWaiter,
+    compressPublicKey
 } from "../.."
 // import { Buffer } from "buffer/"
 
@@ -30,8 +31,8 @@ async function main() {
         return {
             idx: i,
             privateKey: key,
-            publicKey: wallet.publicKey,
-            publicKeyHash: CensusOffChainApi.digestHexClaim(wallet.publicKey)
+            publicKey: compressPublicKey(wallet.publicKey),
+            publicKeyHash: CensusOffChainApi.digestPublicKey(wallet.publicKey)
         }
     })
 

--- a/example/ethers/index.ts
+++ b/example/ethers/index.ts
@@ -1,5 +1,6 @@
 import * as ethers from "ethers"
 import ganache from "ganache-cli"
+import { compressPublicKey, expandPublicKey } from "../../dist"
 
 const config = {
     MNEMONIC: "..."
@@ -50,21 +51,21 @@ async function main() {
 function testPublicKey() {
     // https://docs.ethers.io/ethers.js/html/api-advanced.html#cryptographic-operations
     const privateKey = ethers.Wallet.fromMnemonic(config.MNEMONIC).privateKey
-    const signingKey = new ethers.utils.SigningKey(privateKey);
+    const signingKey = new ethers.utils.SigningKey(privateKey)
 
-    let compressedPublicKey = ethers.utils.computePublicKey(signingKey.publicKey, true);
-    let uncompressedPublicKey = ethers.utils.computePublicKey(signingKey.publicKey, false);
+    let compressedPublicKey = compressPublicKey(signingKey.publicKey)
+    let uncompressedPublicKey = /*expandPublicKey*/(signingKey.publicKey)
 
-    console.log("Compressed public key:", compressedPublicKey);
+    console.log("Compressed public key:", compressedPublicKey)
     // "0x026655feed4d214c261e0a6b554395596f1f1476a77d999560e5a8df9b8a1a3515"
 
-    console.log("Uncompressed public key:", uncompressedPublicKey);
+    console.log("Uncompressed public key:", uncompressedPublicKey)
     // "0x046655feed4d214c261e0a6b554395596f1f1476a77d999560e5a8df9b8a1a35" +
     //   "15217e88dd05e938efdd71b2cce322bf01da96cd42087b236e8f5043157a9c068e"
 
-    let address = ethers.utils.computeAddress(signingKey.publicKey);
+    let address = ethers.utils.computeAddress(signingKey.publicKey)
 
-    console.log('Address: ' + address);
+    console.log('Address: ' + address)
     // "Address: 0x14791697260E4c9A71f18484C9f997B308e59325"
 }
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -27,6 +27,7 @@ import { GatewayApiMethod, BackendApiMethod, ApiMethod } from "../src/models/gat
 import { IGatewayDiscoveryParameters } from "../src/net/gateway-discovery"
 import { ProcessEnvelopeType, ProcessMode, ProcessStatus, ProcessCensusOrigin, ensHashAddress } from "../src/net/contracts"
 import { ContentHashedUri } from "../src/wrappers/content-hashed-uri"
+import { compressPublicKey } from "../src/util/elliptic"
 
 const { Buffer } = require("buffer/")
 
@@ -229,7 +230,7 @@ async function censusMethods() {
     await pool.init()
 
     const censusName = "My census name " + Math.random().toString().substr(2)
-    const adminPublicKeys = [wallet["_signingKey"]().publicKey]
+    const adminPublicKeys = [compressPublicKey(wallet.publicKey)]
     const publicKeyClaims: { key: string, value?: string }[] = [
         { key: Buffer.from("0212d6dc30db7d2a32dddd0ba080d244cc26fcddcc29beb3fcb369564b468b49f1", "hex").toString("base64"), value: "" },
         { key: Buffer.from("033980b22e9432aa2884772570c47a6f78a39bcc08b428161a503eeb91f66b1901", "hex").toString("base64"), value: "" },
@@ -524,7 +525,7 @@ async function useVoteApi() {
     console.log("- Date at block 500:", await VotingApi.estimateDateAtBlock(500, pool))
     console.log("- Block in 200 seconds:", await VotingApi.estimateBlockAtDateTime(new Date(Date.now() + VOCHAIN_BLOCK_TIME * 20), pool))
 
-    const publicKeyHash = CensusOffChainApi.digestHexClaim(wallet["_signingKey"]().publicKey)
+    const publicKeyHash = CensusOffChainApi.digestPublicKey(wallet.publicKey)
     const censusProof = await CensusOffChainApi.generateProof(censusRoot, { key: publicKeyHash }, true, pool)
     const votes = [1, 2, 1]
 
@@ -582,7 +583,7 @@ async function submitVoteBatch() {
             const wallet = Wallet.fromMnemonic(mnemonic, PATH)
             // const myEntityAddress = await wallet.getAddress()
 
-            const publicKeyHash = CensusOffChainApi.digestHexClaim(wallet["_signingKey"]().publicKey)
+            const publicKeyHash = CensusOffChainApi.digestPublicKey(wallet.publicKey)
             const censusProof = await CensusOffChainApi.generateProof(censusRoot, { key: publicKeyHash }, true, pool)
             const votes = [1]
             const { envelope, signature } = await VotingApi.packageSignedEnvelope({ censusOrigin: processParams.censusOrigin, votes, censusProof, processId, walletOrSigner: wallet })
@@ -609,7 +610,7 @@ async function checkSignature() {
     //const signature = await JsonSignature.sign(body, wallet)
 
     const expectedAddress = await wallet.getAddress()
-    const expectedPublicKey = wallet["_signingKey"]().publicKey
+    const expectedPublicKey = compressPublicKey(wallet.publicKey)
 
     let body = { "actionKey": "register", "dateOfBirth": "1975-01-25T12:00:00.000Z", "email": "john@me.com", "entityId": "0xf6515536038e12212adc96395021ad1f1f089a239f0ba4c139d364ededd00c54", "firstName": "John", "lastName": "Mayer", "method": "register", "phone": "5555555", "timestamp": 1582821257721 }
     let givenSignature = "0x3086bf3de0d22d2d51f274d4618ea963b60b1e590f5ef0b1a2df17447746d4503f595e87330fb9cc9387c321acc9e476baedfd0681d864f68f4f1bc84548725c1b"

--- a/example/standard/index.ts
+++ b/example/standard/index.ts
@@ -12,6 +12,7 @@ import { CensusOffChainApi } from "../../src/api/census"
 import { ProcessMetadata, ProcessMetadataTemplate } from "../../src/models/process"
 import { ProcessContractParameters, ProcessMode, ProcessEnvelopeType, ProcessStatus, IProcessCreateParams, ProcessCensusOrigin } from "../../src/net/contracts"
 import { VochainWaiter, EthWaiter } from "../../src/util/waiters"
+import { compressPublicKey } from "../../dist"
 
 
 const CONFIG_PATH = "./config.yaml"
@@ -152,9 +153,9 @@ function createWallets(amount) {
         accounts.push({
             idx: i,
             mnemonic: wallet.mnemonic.phrase,
-            privateKey: wallet["_signingKey"]().privateKey,
-            publicKey: wallet["_signingKey"]().publicKey,
-            publicKeyHash: CensusOffChainApi.digestHexClaim(wallet["_signingKey"]().publicKey)
+            privateKey: wallet.privateKey,
+            publicKey: compressPublicKey(wallet.publicKey),
+            publicKeyHash: CensusOffChainApi.digestPublicKey(wallet.publicKey)
             // address: wallet.address
         })
     }
@@ -169,7 +170,7 @@ async function generatePublicCensusFromAccounts(accounts) {
 
     const censusIdSuffix = require("crypto").createHash('sha256').update("" + Date.now()).digest().toString("hex")
     const claimList: { key: string, value?: string }[] = accounts.map(account => ({ key: account.publicKeyHash, value: "" }))
-    const managerPublicKeys = [entityWallet["_signingKey"]().publicKey]
+    const managerPublicKeys = [compressPublicKey(entityWallet.publicKey)]
 
     if (config.stopOnError) {
         assert(censusIdSuffix.length == 64)

--- a/src/api/census.ts
+++ b/src/api/census.ts
@@ -8,6 +8,7 @@ import { hexStringToBuffer } from "../util/encoding"
 import { CENSUS_MAX_BULK_SIZE } from "../constants"
 import { ERC20Prover } from "@vocdoni/storage-proofs-eth"
 import { Web3Gateway } from "../net/gateway-web3"
+import { compressPublicKey } from "../util/elliptic"
 // import { Buffer } from "buffer/"
 // import ContentURI from "../wrappers/content-uri"
 
@@ -34,11 +35,12 @@ export class CensusOffChainApi {
     }
 
     /**
-     * Hashes the given hex string ECDSA public key and returns the
+     * Hashes the given hex string ECDSA public key (compressed) and returns the
      * base 64 litte-endian representation of the Poseidon hash big int
      */
-    static digestHexClaim(publicKey: string): string {
-        const pubKeyBytes = hexStringToBuffer(publicKey)
+    static digestPublicKey(publicKey: string): string {
+        const compPubKey = compressPublicKey(publicKey)
+        const pubKeyBytes = hexStringToBuffer(compPubKey)
         let hashNumHex: string = hashBuffer(pubKeyBytes).toString(16)
         if (hashNumHex.length % 2 != 0) {
             hashNumHex = "0" + hashNumHex

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export * from "./net/ipfs"
 
 // UTIL
 export * from "./util/data-signing"
+export * from "./util/elliptic"
 export * from "./util/providers"
 export * from "./util/random"
 export * from "./util/signers"

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -1,9 +1,9 @@
 export type HexString = string
 export type ContractAddress = HexString     // e.g. 0x1234567890123456789012345678901234567890
-export type PublicKey = HexString           // Uncompressed ECDSA public key
+export type PublicKey = HexString           // Compressed ECDSA public key
 export type PrivateKey = HexString
-export type EntityId = HexString            // Hash of the entity's address
-export type ProcessId = HexString           // Hash of the organizer's address and the nonce of the process
+export type EntityId = HexString
+export type ProcessId = HexString
 
 export type MultiLanguage<T> = {
     default: T

--- a/src/util/data-signing.ts
+++ b/src/util/data-signing.ts
@@ -1,5 +1,5 @@
 import { Wallet, Signer, utils } from "ethers"
-
+import { compressPublicKey } from "./elliptic"
 
 export class JsonSignature {
     /**
@@ -46,7 +46,7 @@ export class JsonSignature {
      * @param signature Hex encoded signature (created with the Ethereum prefix)
      * @param responseBody JSON object of the `response` or `error` fields
      */
-    static recoverPublicKey(responseBody: any, signature: string): string {
+    static recoverPublicKey(responseBody: any, signature: string, expanded: boolean = false): string {
         if (!signature) throw new Error("Invalid signature")
         else if (!responseBody) throw new Error("Invalid body")
 
@@ -55,7 +55,10 @@ export class JsonSignature {
         const bodyBytes = utils.toUtf8Bytes(strBody)
         const msgHash = utils.hashMessage(bodyBytes)
         const msgHashBytes = utils.arrayify(msgHash)
-        return utils.recoverPublicKey(msgHashBytes, signature)
+
+        const expandedPubKey = utils.recoverPublicKey(msgHashBytes, signature)
+        if (expanded) return expandedPubKey
+        return compressPublicKey(expandedPubKey)
     }
 
     /**

--- a/src/util/elliptic.ts
+++ b/src/util/elliptic.ts
@@ -1,0 +1,9 @@
+import { utils } from "ethers"
+
+export function compressPublicKey(pubKey: string | Uint8Array | Buffer | number[]) {
+    return utils.computePublicKey(pubKey, true)
+}
+
+export function expandPublicKey(pubKey: string | Uint8Array | Buffer | number[]) {
+    return utils.computePublicKey(pubKey, false)
+}

--- a/test/helpers/dvote-service.ts
+++ b/test/helpers/dvote-service.ts
@@ -8,6 +8,7 @@ import { DVoteGateway } from "../../src/net/gateway-dvote"
 import { GatewayInfo } from "../../src/wrappers/gateway-info"
 import { getWallets } from "./web3-service"
 import { BackendApiName, GatewayApiName } from "../../src/models/gateway";
+import { compressPublicKey } from "../../src/util/elliptic";
 
 
 export type TestResponse = {
@@ -116,7 +117,7 @@ export class DevGatewayService {
     // GETTERS
     get uri() { return `http://localhost:${this.port}/dvote` }
     get privateKey() { return this.wallet.privateKey }
-    get publicKey() { return this.wallet["_signingKey"]().compressedPublicKey }
+    get publicKey() { return compressPublicKey(this.wallet.publicKey) }
     get client() {
         return new DVoteGateway({ uri: this.uri, supportedApis: ["file", "census", "vote", "results"], publicKey: this.publicKey })
     }

--- a/test/unit/census.ts
+++ b/test/unit/census.ts
@@ -4,6 +4,7 @@ import { addCompletionHooks } from "../mocha-hooks"
 import { Wallet } from "ethers"
 
 import { CensusOffChainApi } from "../../src/api/census"
+import { compressPublicKey } from "../../dist"
 
 addCompletionHooks()
 
@@ -14,52 +15,52 @@ describe("Census", () => {
         // it("Should be updated once circomlib JS is also updated")
 
         it("Should hash public keys properly", () => {
-            let hexClaim
-            let b64Hash
+            let hexClaim: string
+            let b64Hash: string
 
             hexClaim = "0x045a126cbbd3c66b6d542d40d91085e3f2b5db3bbc8cda0d59615deb08784e4f833e0bb082194790143c3d01cedb4a9663cb8c7bdaaad839cb794dd309213fcf30"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("nGOYvS4aqqUVAT9YjWcUzA89DlHPWaooNpBTStOaHRA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("3cZFfsN4tUAhkBsnZ9AyGzK0Sg5PLKMvqRHclsxQcCY=")
 
             hexClaim = "0x049969c7741ade2e9f89f81d12080651038838e8089682158f3d892e57609b64e2137463c816e4d52f6688d490c35a0b8e524ac6d9722eed2616dbcaf676fc2578"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("j7jJlnBN73ORKWbNbVCHG9WkoqSr+IEKDwjcsb6N4xw=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("pKH7yoPwmArs52+sAYP28F2Bbi4amtrVJoe4b6S9dRs=")
 
             hexClaim = "0x049622878da186a8a31f4dc03454dbbc62365060458db174618218b51d5014fa56c8ea772234341ae326ce278091c39e30c02fa1f04792035d79311fe3283f1380"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("6CUGhnmKQchF6Ter05laVgQYcEWm0p2qlLzX24rk3Ck=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("RPNeqeFnKzLc6GKvi4iA0EmZRAlpp0BpTJkBfvPFmC8=")
 
             hexClaim = "0x04e355263aa6cbc99d2fdd0898f5ed8630115ad54e9073c41a8aa0df6d75842d8b8309d0d26a95565996b17da48f8ddff704ebcd1d8a982dc5ba8be7458c677b17"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("k0UwNtWW4UQifisXuoDiO/QGRZNNTY7giWK1Nx/hoSo=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("Zk+WTQNF1+88t4qPjLqpO1qexc2fEeSEaetVn7B6OzA=")
 
             hexClaim = "0x04020d62c94296539224b885c6cdf79d0c2dd437471425be26bf62ab522949f83f3eed34528b0b9a7fbe96e50ca85471c894e1aa819bbf12ff78ad07ce8b4117b2"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("5EhP0859lic41RIpIrnotv/BCR7v5nVcXsXkTXlbuhI=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("wJ+U4/1yBMbmnwj8s0im9iQkVaR49EOuN/N2LFyFeBA=")
 
             hexClaim = "0x046bd65449f336b888fc36c64708940da0d1c864a0ac46236f60b455841a4d15c9b815ed725093b3266aaca2f15210d14a1eadf34efeda3bd44a803fbf1590cfba"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("oseI7fM8wWIYslDUOXJne7AOiK+IpFL3q8MTqiZHWw8=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("r1Z6UwB6iX0l0Yx2FzOh8Nzv7VuTKqNF+4eYqcqaXjA=")
 
             hexClaim = "0x0412cf2bd4a9613ad988f7f008a5297b8e8c98df8759a2ef9d3dfae63b3870cfbb78d35789745f82710da61a61a9c06c6f6166bf1d5ce73f9416e6b67713001aa2"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("9Y3JcjUHZLGmENRQpnML/+TG2EbHWjU46h+LtT9sQi8=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("8YKaewMj9cIl/gPgITLbrUGYnLCo00pjTF2vFwI6CRc=")
 
             hexClaim = "0x04a2e6914db4a81ea9ec72e71b41cf88d4bc19ea54f29ae2beb3db8e4acf6531b5c163e58427831832b10fce899a030d12e82a398d4eeefe451c7e261fba973be4"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("Llx5F6lP/hbU6ZTT10Q5PF+7o1VdylvrolT8vSHJMAA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("H+3VsMxmC5VsTSMawhh0kQ0Kt3EKQQl8ISsNp6TCHR8=")
 
             hexClaim = "0x041508189a6f1737f50dd2c603c1ded8a83f97073d33cbb317e7409c1487b8351aa2b89455cda61ce8ed3ba3c130372870b187239b900da8948a53ca3e02db9aaf"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("MyRpb4ZDTwtJNflc8ZbZdmKOf+fuZjUEZkgZMCmlKxw=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("Pf/Q2nfiYnrUTS1Pabe1YjwdqLFX6Hc5M4KwZT9Nuxc=")
 
             hexClaim = "0x04f11597483032666b20ec51b27e1337577f63a5e1d5962575b555bf899380ae15482f031a297094b0c60980f3c4f1f7ad2346de5357ad82a6a3d4eef2bd1956c6"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("ytwkzcBixiBMsblxEEPpiDFV6MCBG/IY+XUc6/+xIQ8=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("D3uiR1w5Vu/7OPZdBZWxjq4FHsPF1vdU8uMsduUD0x0=")
 
             hexClaim = "0x044c01f3d0ef3d60652aa7c6489b2f10edcae1b04a10460ab2d5e4bd752eb0686cac7aa6057fd4c65606e8a4c33c0b519b1764229395cde2c8537ee01136ef0776"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("VS5c2JQT3x++ltSQHqnCFIBHttdjU2Lk2RuCGkUhnQ8=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("6fn61Hoz4P0v8STJSIUdz6GNi1NyyRBCj07qvQLToSw=")
         })
 
         it("Hashed public keys should be 32 bytes long", () => {
@@ -68,75 +69,79 @@ describe("Census", () => {
             let buff: Buffer
 
             hexClaim = "0x04c94699a259ec27e1cf67fe46653f0dc2f38e6d32abb33b45fc9ffe793171a44b4ff5c9517c1be22f8a47915debcf1e512717fe33986f287e79d2f3099725f179"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("uJM6qiWAIIej9CGonWlR0cU64wqtdlh+csikpC6wSgA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("fKYmOKLR9mG/VnmIg6I2aLe7ysowrTqkLLAfVazfHAs=")
             buff = Buffer.from(b64Hash, "base64")
             expect(buff.length).to.eq(32)
 
             hexClaim = "0x0424a71e7c24b38aaeeebbc334113045885bfae154071426e21c021ebc47a5a85a3a691a76d8253ce6e03bf4e8fe154c89b2d967765bb060e61360305d1b8df7c5"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("9wxP7eLFnTk5VDsj9rXL63r7QPKTTjCkNhjZri1nEQA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("1unO9DU5kr7lbPUT9YyPY/EQcDr2KFyDJGPR3tTPSCs=")
             buff = Buffer.from(b64Hash, "base64")
             expect(buff.length).to.eq(32)
 
             hexClaim = "0x04ff51151c6bd759d723af2d0571df5e794c28b204242f4b540b0d3449eab192cafd44b241c96b39fa7dd7ead2d2265a598a23cba0f54cb79b9829d355d74304a2"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("iS7BUPgGpY/WAdWyZb0s1wE21tMz5ZWBc8LJ6jgqSwA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("lV353gFkyjwoh8bjmzJ35ndkC2hof7o0+Tw2x9VPYQs=")
             buff = Buffer.from(b64Hash, "base64")
             expect(buff.length).to.eq(32)
 
             hexClaim = "0x043f10ff1b295bf4d2f24c40c93cce04210ae812dd5ad1a06d5dafd9a2e18fa1247bdf36bef6a9e45e97d246cfb8a0ab25c406cf6fe7569b17e83fd6d33563003a"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("CCxtK0qT7cTxCS7e4uONSHcPQdbQzBqrC3GQvFz4KwA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("GnkH1v5cCoLRddAJL13rA5BCyaixVzD8Su2x5FEW4iE=")
             buff = Buffer.from(b64Hash, "base64")
             expect(buff.length).to.eq(32)
 
             hexClaim = "0x0409d240a33ca9c486c090135f06c5d801aceec6eaed94b8bef1c9763b6c39708819207786fe92b22c6661957e83923e24a5ba754755b181f82fdaed2ed3914453"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("3/AaoqHPrz20tfLmhLz4ay5nrlKN5WiuvlDZkfZyfgA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("DuOZ467hKLeRjJbhuZy/h4s6FnjLRXAJDSPElEYTOwo=")
             buff = Buffer.from(b64Hash, "base64")
             expect(buff.length).to.eq(32)
 
             hexClaim = "0x04220da30ddd87fed1b65ef75706507f397138d8cac8917e118157124b7e1cf45b8a38ac8c8b65a6ed662d62b09d100e53abacbc27500bb9d0365f3d6d60a981fa"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("YiEgjvg1VeCMrlWJkAuOQIgDX1fWtkHk9OBJy225UgA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("9pAfgqDFOTkUgYmIRDiopFWNgXIb069EPaInKgGLKRA=")
             buff = Buffer.from(b64Hash, "base64")
             expect(buff.length).to.eq(32)
 
             hexClaim = "0x04acdbbdba45841ddcc1c3cb2e8b696eae69ba9d57686bff0cd58e4033a08d9dc6c272a3577508cdb18bdb1c6fcc818538664bb6dc4cc32ee668198c7be044800c"
-            b64Hash = CensusOffChainApi.digestHexClaim(hexClaim)
-            expect(b64Hash).to.equal("UPqwKZBMhq21uwgLWJUFMgCBMPzhseiziVaqN4EQvwA=")
+            b64Hash = CensusOffChainApi.digestPublicKey(hexClaim)
+            expect(b64Hash).to.equal("oWlFPwaVT762OHFYdgcGbvkDgSwbMqf5DiqdLwlzohE=")
             buff = Buffer.from(b64Hash, "base64")
             expect(buff.length).to.eq(32)
-
         })
 
         it("Should fail on invalid hex strings", () => {
             let wallet = Wallet.fromMnemonic("soul frequent purity regret noble husband weapon scheme cement lamp put regular envelope physical entire", "m/44'/60'/0'/0/0")
-            let pubKey = wallet["_signingKey"]().publicKey
 
+            let pubKey = compressPublicKey(wallet.publicKey)
             expect(() => {
-                CensusOffChainApi.digestHexClaim(pubKey)
+                CensusOffChainApi.digestPublicKey(pubKey)
+            }).to.not.throw
+
+            pubKey = wallet.publicKey
+            expect(() => {
+                CensusOffChainApi.digestPublicKey(pubKey)
             }).to.not.throw
 
             expect(() => {
-                CensusOffChainApi.digestHexClaim("hello world 1234")
+                CensusOffChainApi.digestPublicKey("hello world 1234")
             }).to.throw
 
             expect(() => {
-                CensusOffChainApi.digestHexClaim("!\"·$%&")
+                CensusOffChainApi.digestPublicKey("!\"·$%&")
             }).to.throw
 
             expect(() => {
-                CensusOffChainApi.digestHexClaim("")
+                CensusOffChainApi.digestPublicKey("")
             }).to.throw
 
             expect(() => {
-                CensusOffChainApi.digestHexClaim("ZXCVBNM")
+                CensusOffChainApi.digestPublicKey("ZXCVBNM")
             }).to.throw
 
             expect(() => {
-                CensusOffChainApi.digestHexClaim(",.-1234")
+                CensusOffChainApi.digestPublicKey(",.-1234")
             }).to.throw
         })
     })

--- a/test/unit/elliptic.ts
+++ b/test/unit/elliptic.ts
@@ -1,0 +1,51 @@
+import "mocha" // using @types/mocha
+import { expect } from "chai"
+import { addCompletionHooks } from "../mocha-hooks"
+import { compressPublicKey, expandPublicKey } from "../../src/util/elliptic"
+
+addCompletionHooks()
+
+describe("Public key", () => {
+    const items = [
+        {
+            compressed: '0x02ab1a7f0cb763c4a8b30a2b8e3d0324e8db5cf2d25e906cae400ae7265083e7e2',
+            expanded: '0x04ab1a7f0cb763c4a8b30a2b8e3d0324e8db5cf2d25e906cae400ae7265083e7e20a7e6a0e1bf47f7d5280952b80b5fe9d380189243219518b7c62e57f68ed1c66'
+        },
+        {
+            compressed: '0x02531645fa5df607f2016070c12dd559d4a72a1acf61f2d499eb470a9aa42ebd17',
+            expanded: '0x04531645fa5df607f2016070c12dd559d4a72a1acf61f2d499eb470a9aa42ebd1765cae6e30245c4e742a158bc038dd93d90bb61298a4108219a41c74d24a90fc4'
+        },
+        {
+            compressed: '0x024014610da034308afe245ff6a120e5e4c8f6f7a07a69b966e46d1e1ccf320d6b',
+            expanded: '0x044014610da034308afe245ff6a120e5e4c8f6f7a07a69b966e46d1e1ccf320d6b6985c44c37468b587e1632aa12efab216992ffb2e577dbe50593c6cae07b02b2'
+        },
+        {
+            compressed: '0x0260c8ffa4cf0d52a2069a4d47f59b8fe0b8dd469bed2cf98196c53b1f5327d071',
+            expanded: '0x0460c8ffa4cf0d52a2069a4d47f59b8fe0b8dd469bed2cf98196c53b1f5327d071cb9495b461863a583fcda564e245e7504d8f304dbb10f62870cdd6ef8befc7fe'
+        },
+        {
+            compressed: '0x02dd06d88f8777da2a250920456df44c7eca71f7b3d9f18c0101d06a3e6d09a382',
+            expanded: '0x04dd06d88f8777da2a250920456df44c7eca71f7b3d9f18c0101d06a3e6d09a382b9e8c3fe821df14d6dddd77a49ed47d9b55f680323eb2e3b5a319cf14caddafe'
+        },
+        {
+            compressed: '0x02ca8f91c36ac0a4a08f77849079584d5a3d35c6baafc92762c1e1cd8967b87967',
+            expanded: '0x04ca8f91c36ac0a4a08f77849079584d5a3d35c6baafc92762c1e1cd8967b879674bd320cc2e6a4693f6297b8e5b2f00a1bdf5d4b4f392834f8dfe0dacc74f326a'
+        },
+        {
+            compressed: '0x0363ebf3ac245f883bc392a6df47fef9058f6408dd67d2a5d51c307bb66f35945a',
+            expanded: '0x0463ebf3ac245f883bc392a6df47fef9058f6408dd67d2a5d51c307bb66f35945a046f785eb9bf177eeff87ca57a559620fc995fd2f613326dab9dcb02618d768d'
+        }
+    ]
+
+    it("Should compress publickeys", () => {
+        items.forEach(item => {
+            expect(compressPublicKey(item.expanded)).to.eq(item.compressed)
+        })
+    })
+
+    it("Should compress publickeys", () => {
+        items.forEach(item => {
+            expect(expandPublicKey(item.compressed)).to.eq(item.expanded)
+        })
+    })
+})

--- a/test/unit/processes.ts
+++ b/test/unit/processes.ts
@@ -36,6 +36,7 @@ import ProcessMetadataBuilder from "../builders/process-metadata"
 import NamespaceBuilder from "../builders/namespace"
 import { Web3Gateway } from "../../src/net/gateway-web3"
 import { BytesSignature } from "../../src/util/data-signing"
+import { compressPublicKey } from "../../dist"
 const {
     VoteEnvelope,
     Proof,
@@ -224,7 +225,8 @@ describe("Governance Process", () => {
             const pkg1: IVotePackage = JSON.parse(Buffer.from(envelope1.getVotepackage()).toString())
             expect(pkg1.votes.length).to.eq(3)
             expect(pkg1.votes).to.deep.equal([1, 2, 3])
-            expect(BytesSignature.isValid(signature1, wallet._signingKey().publicKey, e1)).to.eq(true)
+            expect(BytesSignature.isValid(signature1, compressPublicKey(wallet.publicKey), e1)).to.eq(true)
+            expect(BytesSignature.isValid(signature1, wallet.publicKey, e1)).to.eq(true)
 
             processId = "0x36c886bd2e18605bf03a0428be100313a0f6e568c470d135d3cb72e802045faa"
             siblings = "0x0003000000100000000002000000000300000000000400000000000050000006f0d72fbd8b3a637488107b0d8055410180ec017a4d76dbb97bee1c3086a25e25b1a6134dbd323c420d6fc2ac3aaf8fff5f9ac5bc0be5949be64b7cfd1bcc5f1f"
@@ -236,7 +238,8 @@ describe("Governance Process", () => {
             const pkg2: IVotePackage = JSON.parse(Buffer.from(envelope2.getVotepackage()).toString())
             expect(pkg2.votes.length).to.eq(3)
             expect(pkg2.votes).to.deep.equal([5, 6, 7])
-            expect(BytesSignature.isValid(signature2, wallet._signingKey().publicKey, e2)).to.eq(true)
+            expect(BytesSignature.isValid(signature2, compressPublicKey(wallet.publicKey), e2)).to.eq(true)
+            expect(BytesSignature.isValid(signature2, wallet.publicKey, e2)).to.eq(true)
 
             expect(async () => {
                 await VotingApi.packageSignedEnvelope({ censusOrigin: new ProcessCensusOrigin(ProcessCensusOrigin.OFF_CHAIN_TREE), votes: ["1", "2", "3"], censusProof: siblings, processId, walletOrSigner: wallet } as any)

--- a/test/unit/standalone-wallets.ts
+++ b/test/unit/standalone-wallets.ts
@@ -6,6 +6,7 @@ import { utils } from "ethers"
 import { WalletUtil } from "../../src/util/signers"
 import { Random } from "../../src/util/random"
 import { JsonSignature, BytesSignature } from "../../src/util/data-signing"
+import { compressPublicKey } from "../../dist"
 
 addCompletionHooks()
 
@@ -45,7 +46,8 @@ describe("Standalone Ethereum wallets", () => {
 
         const wallet = WalletUtil.fromSeededPassphrase(passphrase, hexSeed)
         expect(wallet.privateKey).to.eq("0x58c6192cbffe39d20f6dbaa2957a6d6a4116489a2bb66caab5c4a0bfa83d887b")
-        expect(wallet["_signingKey"]().publicKey).to.eq("0x04de6d532b6979899729f9e98869888ea7fdbc446f9f3ea732d23c7bcd10c784d041887d48ebc392c4ff51882ae569ca1553f6ab6538664bced6cca6855acbbade")
+        expect(compressPublicKey(wallet.publicKey)).to.eq("0x02de6d532b6979899729f9e98869888ea7fdbc446f9f3ea732d23c7bcd10c784d0")
+        expect(wallet.publicKey).to.eq("0x04de6d532b6979899729f9e98869888ea7fdbc446f9f3ea732d23c7bcd10c784d041887d48ebc392c4ff51882ae569ca1553f6ab6538664bced6cca6855acbbade")
         expect(await wallet.getAddress()).to.eq("0xf76564CBF51B1F050c84fC01400088ACD2704F2e")
 
         const msg = utils.toUtf8Bytes("Hello")
@@ -137,6 +139,7 @@ describe("Standalone Ethereum wallets", () => {
 
         const signature = await JsonSignature.sign(jsonBody, wallet)
 
-        expect(JsonSignature.isValid(signature, wallet["_signingKey"]().publicKey, jsonBody)).to.be.true
+        expect(JsonSignature.isValid(signature, compressPublicKey(wallet.publicKey), jsonBody)).to.be.true
+        expect(JsonSignature.isValid(signature, wallet.publicKey, jsonBody)).to.be.true
     })
 })


### PR DESCRIPTION
This is a breaking change for existing censuses

- Using compressed keys everywhere
    - Adding `compressPublicKey` and `expandPublicKey`
    - `digestHexClaim` is now `digestPublicKey`
    - `digestPublicKey` compresses all keys