### PR TITLE
Remove /ping call and use getInfo instead

### DIFF
--- a/src/net/gateway-dvote.ts
+++ b/src/net/gateway-dvote.ts
@@ -222,27 +222,14 @@ export class DVoteGateway {
     }
 
     /**
-     * Checks the health of the current Gateway. Resolves the promise when successful and rejects it otherwise.
+     * Alias of updateGatewayStatus, for convenience purposes.
      */
     public isUp(timeout: number = GATEWAY_SELECTION_TIMEOUT): Promise<void> {
-        if (!this.client) return Promise.reject(new Error("The client is not initialized"))
-        const uri = parseURL(this._uri)
-
-        if (uri.host.length === 0) {
-            return Promise.reject(new Error("Invalid Gateway URL"))
-        }
-        return promiseWithTimeout(
-            this.checkPing()
-                .then((isUp) => {
-                    if (isUp !== true) throw new Error("No ping reply")
-                    return this.updateGatewayStatus(timeout)
-                }),
-            timeout || 4 * 1000,
-            "The DVote Gateway seems to be down")
+        return this.updateGatewayStatus(timeout)
     }
 
     /** Retrieves the status of the gateway and updates the internal status */
-    public updateGatewayStatus(timeout?: number): Promise<any> {
+    public updateGatewayStatus(timeout?: number): Promise<void> {
         return this.getInfo(timeout)
             .then((result) => {
                 if (!result) throw new Error("Could not update")
@@ -277,21 +264,6 @@ export class DVoteGateway {
             message = (error.message) ? message + ": " + error.message : message
             throw new Error(message)
         }
-    }
-
-    /**
-     * Checks the ping response of the gateway
-     * @returns A boolean representing wheter the gateway responded correctly or not
-     */
-    public checkPing(): Promise<boolean> {
-        if (!this.client) return Promise.reject(new Error("The client is not initialized"))
-        const uri = parseURL(this._uri)
-        const pingUrl = `${uri.protocol}//${uri.host}/ping`
-
-        return promiseWithTimeout(axios.get(pingUrl), 4 * 1000)
-            .then((response?: AxiosResponse<any>) => (
-                response != null && response.status === 200 && response.data === "pong"
-            ))
     }
 
     /**

--- a/test/helpers/dvote-service.ts
+++ b/test/helpers/dvote-service.ts
@@ -62,7 +62,6 @@ export class DevGatewayService {
         return this.stop().then(() => {
             const app = express()
             app.use(json())
-            app.get("/ping", (req, res) => res.send("pong"))
             app.post("/dvote", (req, res, next) => this.handleRequest(req, res, next))
 
             return new Promise((resolve) => {


### PR DESCRIPTION
This MR removes the call to `/ping` as it was redundant, specially now that we're properly getting all the gateways info using their `getInfo` method.

The `isUp` method has been left as a convenience alias, because the web3 gateway also has an `isUp` method, so it made kind of sense to maintain that same method in the dvote gateway too.