### PR TITLE
Force `sendRequest` to treat responses as arraybuffer

### DIFF
--- a/test/helpers/dvote-service.ts
+++ b/test/helpers/dvote-service.ts
@@ -3,7 +3,8 @@ import { NextFunction, Request, Response } from "express"
 import { json } from "body-parser"
 import { Server } from "http";
 import { Wallet } from "ethers"
-import { JsonSignature } from "../../src/util/data-signing"
+import { TextEncoder } from "util"
+import { BytesSignature } from "../../src/util/data-signing"
 import { DVoteGateway } from "../../src/net/gateway-dvote"
 import { GatewayInfo } from "../../src/wrappers/gateway-info"
 import { getWallets } from "./web3-service"
@@ -95,7 +96,8 @@ export class DevGatewayService {
                 response,
                 signature: ""
             }
-            responseData.signature = await JsonSignature.sign(responseData.response, this.wallet)
+            const responseBytes = new TextEncoder().encode(JSON.stringify(response))
+            responseData.signature = await BytesSignature.sign(responseBytes, this.wallet)
             this.interactionCount++
             res.send(responseData)
         }


### PR DESCRIPTION
This change is made because the signatures may differ due to encoding issues (i.e. a response containing an ampersand could be signed differently).

Forcing the requests to treat their responses as arraybuffers fixes this, and allows us to remove code in sendRequest that was checking for the received response. As we are pretty sure all responses will be returned as arraybuffers, we can just treat them as so.

There's something I don't understand though: I also had to rewrite the mock in the tests which was injecting the tests signatures. Using JsonSignature to inject those signatures was making all the related tests to fail with an `Unvalid signature` error, but changing that to use a `BytesSignature` instead fixed the issue.

As said, I don't get why is happening this. Both methods should be signing the same way (actually, there are tests demonstrating it works well), and apparently they aren't **only on the tests** (I wasn't having any issue while checking the changes linked to the frontend manager project).