### PR TITLE
Fix false-positive in supportsMethod

### DIFF
--- a/src/net/gateway-dvote.ts
+++ b/src/net/gateway-dvote.ts
@@ -226,18 +226,12 @@ export class DVoteGateway {
      */
     public supportsMethod(method: ApiMethod): boolean {
         if (allApis.info.includes(method as InfoApiMethod)) return true
-        // Gateway
-        else if (allApis.file.includes(method as GatewayApiMethod))
-            return this.supportedApis.includes("file")
-        else if (allApis.census.includes(method as GatewayApiMethod))
-            return this.supportedApis.includes("census")
-        else if (allApis.vote.includes(method as GatewayApiMethod))
-            return this.supportedApis.includes("vote")
-        else if (allApis.results.includes(method as GatewayApiMethod))
-            return this.supportedApis.includes("results")
-        // Registry
-        else if (allApis.registry.includes(method as BackendApiMethod))
-            return this.supportedApis.includes("registry")
+
+        for (const api of this.supportedApis) {
+            if (allApis[api].includes(method as GatewayApiMethod | BackendApiMethod)) {
+                return true
+            }
+        }
         return false
     }
 }

--- a/src/wrappers/gateway-info.ts
+++ b/src/wrappers/gateway-info.ts
@@ -1,10 +1,10 @@
-import { GatewayApiName } from "../models/gateway"
+import { BackendApiName, GatewayApiName } from "../models/gateway"
 
 // const uriPattern = /^([a-z][a-z0-9+.-]+):(\/\/([^@]+@)?([a-z0-9.\-_~]+)(:\d+)?)?((?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@])+(?:\/(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@])*)*|(?:\/(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@])+)*)?(\?(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@]|[/?])+)?(\#(?:[a-z0-9-._~]|%[a-f0-9]|[!$&'()*+,;=:@]|[/?])+)?$/i
 
 export class GatewayInfo {
     private dvoteUri: string
-    private supportedApiList: GatewayApiName[]
+    private supportedApiList: GatewayApiName[] | BackendApiName[]
     private web3Uri: string
     private pubKey: string
 
@@ -14,7 +14,7 @@ export class GatewayInfo {
     public get publicKey() { return this.pubKey }
 
     /** Bundles the given coordinates into an object containing the details of a Gateway */
-    constructor(dvoteUri: string = null, supportedApis: GatewayApiName[] = [], web3Uri: string, pubKey?: string) {
+    constructor(dvoteUri: string = null, supportedApis: GatewayApiName[] | BackendApiName[] = [], web3Uri: string, pubKey?: string) {
         if (!dvoteUri && !web3Uri) throw new Error("DVote URI or Web3 URI is required")
 
         if (dvoteUri) {

--- a/test/integration/gateway.ts
+++ b/test/integration/gateway.ts
@@ -77,6 +77,28 @@ describe("DVote gateway client", () => {
             expect(dvoteServer1.interactionCount).to.equal(2)
             expect(dvoteServer2.interactionCount).to.equal(2)
         })
+
+        it("Should allow calls to methods with the same name in different api", async () => {
+            const port1 = 9010
+            const dvoteServer1 = new DevGatewayService({
+                port: port1,
+                responses: [
+                    {...defaultConnectResponse, apiList: ['registry']},
+                    defaultDummyResponse,
+                ]
+            })
+            await dvoteServer1.start()
+            const gatewayUri1 = dvoteServer1.uri
+            expect(dvoteServer1.interactionCount).to.equal(0)
+
+            const gatewayInfo1 = new GatewayInfo(gatewayUri1, ["registry"], "https://server/path", "")
+            let gwClient = new DVoteGateway(gatewayInfo1)
+            expect(gwClient.uri).to.equal(gatewayInfo1.dvote)
+            await gwClient.init()
+            await gwClient.sendRequest({ method: "addCensus", censusId: "1234", targetId: "2345", census: {name: "test"} })
+
+            await dvoteServer1.stop()
+        })
     })
 
     describe("WebSocket requests", () => {


### PR DESCRIPTION
### The problem

The logic behind `supportsMethod`, when calling `addCensus`, was going inside the condition checking for the census api, instead than checking in the registry.

This was blocking requests to the backends for this specific call (as there are no more repeated method names).

### The solution

Iterate only over the supported Api list, and check for the method in available apis.
