### PR TITLE
Changed `JsonRpcProvider` for `StaticJsonRpcProvider`

### DIFF
--- a/src/net/gateway-bootnode.ts
+++ b/src/net/gateway-bootnode.ts
@@ -51,13 +51,13 @@ export class GatewayBootnode {
                 break
             case "xdai":
                 if (environment === "prod") {
-                    provider = new providers.JsonRpcProvider(XDAI_PROVIDER_URI, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_ENS_REGISTRY_ADDRESS })
+                    provider = new providers.StaticJsonRpcProvider(XDAI_PROVIDER_URI, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_ENS_REGISTRY_ADDRESS })
                     break
                 }
-                provider = new providers.JsonRpcProvider(XDAI_PROVIDER_URI, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_STG_ENS_REGISTRY_ADDRESS })
+                provider = new providers.StaticJsonRpcProvider(XDAI_PROVIDER_URI, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_STG_ENS_REGISTRY_ADDRESS })
                 break
             case "sokol":
-                provider = new providers.JsonRpcProvider(SOKOL_PROVIDER_URI, { chainId: SOKOL_CHAIN_ID, name: "sokol", ensAddress: SOKOL_ENS_REGISTRY_ADDRESS });
+                provider = new providers.StaticJsonRpcProvider(SOKOL_PROVIDER_URI, { chainId: SOKOL_CHAIN_ID, name: "sokol", ensAddress: SOKOL_ENS_REGISTRY_ADDRESS });
                 break
             default: throw new Error("Invalid Network ID")
         }

--- a/src/util/providers.ts
+++ b/src/util/providers.ts
@@ -18,12 +18,12 @@ export class ProviderUtil {
         switch (networkId) {
             case "xdai":
                 if (environment === 'prod')
-                    return new providers.JsonRpcProvider(uri, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_ENS_REGISTRY_ADDRESS })
-                return new providers.JsonRpcProvider(uri, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_STG_ENS_REGISTRY_ADDRESS })
+                    return new providers.StaticJsonRpcProvider(uri, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_ENS_REGISTRY_ADDRESS })
+                return new providers.StaticJsonRpcProvider(uri, { chainId: XDAI_CHAIN_ID, name: "xdai", ensAddress: XDAI_STG_ENS_REGISTRY_ADDRESS })
             case "sokol":
-                return new providers.JsonRpcProvider(uri, { chainId: SOKOL_CHAIN_ID, name: "sokol", ensAddress: SOKOL_ENS_REGISTRY_ADDRESS })
+                return new providers.StaticJsonRpcProvider(uri, { chainId: SOKOL_CHAIN_ID, name: "sokol", ensAddress: SOKOL_ENS_REGISTRY_ADDRESS })
             default:
-                return new providers.JsonRpcProvider(uri)
+                return new providers.StaticJsonRpcProvider(uri)
         }
     }
 


### PR DESCRIPTION
In order to avoid so many calls to the method `eth_chainId` from the web3 endpoint, the provider has been changed from  `JsonRpcProvider` to `StaticJsonRpcProvider`.

More information about the discussion in the ethers.js library can be found here: https://github.com/ethers-io/ethers.js/issues/901