### PR TITLE
Multiple choice results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # DVote JS changelog
 
+## 1.12.0
+
+- Supporting multiple choice (single question) results
+    - https://docs.vocdoni.io/architecture/data-schemes/ballot-protocol.html#vocdoni-results-interpretation
+- BREAKING:
+    - `VotingApi.getRawResults` no longer exists
+        - Use `VotingApi.getResults()` instead
+    - `VotingApi.getResultsDigest()` no longer exists. 
+    - Arrange results with:
+        - `Voting.digestSingleChoiceResults(results, metadata)`
+        - `Voting.digestSingleQuestionResults(results, metadata)`
+    - Types `DigestedProcessResults` and `DigestedProcessResultItem` no longer exist
+        - Use `ProcessResultsSingleChoice`, `ProcessResultsSingleQuestion` instead
+
 ## 1.11.4
 
 - Retrieving light storage proofs for ERC20 tokens instead of full block ones

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvote-js",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "description": "Javascript/Typescript library to interact with Vocdoni voting processes",
   "main": "dist/index",
   "types": "dist/index",

--- a/src/api/voting.ts
+++ b/src/api/voting.ts
@@ -1,9 +1,8 @@
 import { Wallet, Signer, utils, ContractTransaction, BigNumber, providers } from "ethers"
-import { Gateway } from "../net/gateway"
 import { GatewayArchive, GatewayArchiveApi } from "../net/gateway-archive";
 import { FileApi } from "./file"
 import { EntityApi } from "./entity"
-import { ProcessMetadata, checkValidProcessMetadata, DigestedProcessResults, DigestedProcessResultItem, INewProcessParams, IProofEVM, IProofCA, IProofGraviton, INewProcessErc20Params } from "../models/process"
+import { ProcessMetadata, checkValidProcessMetadata, INewProcessParams, IProofEVM, IProofCA, IProofGraviton, INewProcessErc20Params, ProcessResultsSingleChoice, SingleChoiceQuestionResults } from "../models/process"
 import {
     VOCHAIN_BLOCK_TIME,
     XDAI_GAS_PRICE,
@@ -39,6 +38,7 @@ import { ApiMethod } from "../models/gateway"
 import { IGatewayClient, IGatewayDVoteClient, IGatewayWeb3Client } from "../common"
 import { Poseidon } from "../crypto/hashing"
 import { uintArrayToHex } from "../util/encoding"
+import { ResultsNotAvailableError } from "../errors/results";
 
 export const CaBundleProtobuf: any = CAbundle
 
@@ -1020,14 +1020,10 @@ export namespace VotingApi {
             })
     }
 
-    /**
-     * Fetches the results for a given processId
-     * @param processId
-     * @param gateway
-     * @param params
-     * @returns Results, vote process  type, vote process state
-     */
-    export function getRawResults(processId: string, gateway: IGatewayClient, params: { skipArchive?: boolean } = {}): Promise<{ results: string[][], status: ProcessStatus, envelopHeight: number }> {
+    // Results
+    export type RawResults = { results: string[][], status: ProcessStatus, envelopHeight: number }
+
+    function fetchRawResults(processId: string, gateway: IGatewayClient, params: { skipArchive?: boolean } = {}): Promise<RawResults> {
         if (!processId)
             return Promise.reject(new Error("No process ID provided"))
         else if (!gateway)
@@ -1052,23 +1048,30 @@ export namespace VotingApi {
     }
 
     /**
-     * Fetches the results for a given processId and arranges them with the titles and their respective options.
+     * Retrieves the results for a given processId. Resolved from the archive if needed.
      * @param processId
      * @param gateway
      * @returns Results, vote process  type, vote process state
      */
-    export async function getResultsDigest(processId: string, gateway: IGatewayClient): Promise<DigestedProcessResults> {
+    export async function getResults(processId: string, gateway: IGatewayClient) {
         if (!processId)
             throw new Error("No process ID provided")
         else if (!gateway)
             throw new Error("Invalid gateway client")
 
         processId = processId.startsWith("0x") ? processId : "0x" + processId
-        const emptyResults = { totalVotes: 0, questions: [] }
+        const emptyResults = {
+            results: [[]] as string[][],
+            status: new ProcessStatus(ProcessStatus.READY),
+            envelopHeight: 0
+        }
 
         try {
             const processState = await getProcessState(processId, gateway)
-            if (processState.status == ProcessStatus.CANCELED) return emptyResults
+            if (processState.status == ProcessStatus.CANCELED) {
+                emptyResults.status = new ProcessStatus(ProcessStatus.CANCELED)
+                return emptyResults
+            }
 
             // Encrypted?
             let procKeys: ProcessKeys, retries: number
@@ -1095,25 +1098,10 @@ export namespace VotingApi {
                 if (!procKeys || !procKeys.encryptionPrivKeys || !procKeys.encryptionPrivKeys.length) return emptyResults
             }
 
-            const { results, status: resultsStatus, envelopHeight } = await getRawResults(processId, gateway)
-            const metadata = await getProcessMetadata(processId, gateway)
-
-            const resultsDigest: DigestedProcessResults = { totalVotes: envelopHeight, questions: [] }
-            const zippedQuestions = metadata.questions.map((e, i) => ({ meta: e, result: results[i] }))
-            resultsDigest.questions = zippedQuestions.map((zippedEntry, idx): DigestedProcessResultItem => {
-                const zippedOptions = zippedEntry.meta.choices.map((e, i) => ({ title: e.title, value: zippedEntry.result[i] }))
-                return {
-                    title: zippedEntry.meta.title,
-                    voteResults: zippedOptions.map((option) => ({
-                        title: option.title,
-                        votes: BigNumber.from(option.value || 0),
-                    })),
-                }
-            })
-            return resultsDigest
+            return fetchRawResults(processId, gateway)
         }
         catch (err) {
-            throw new Error("The results are not available")
+            throw new ResultsNotAvailableError()
         }
     }
 
@@ -1431,6 +1419,31 @@ export namespace VotingApi {
         else if (processId.length != 64) return null
 
         return utils.keccak256(utils.arrayify("0x" + address + processId))
+    }
+}
+
+export namespace Voting {
+    /**
+     * Arranges the raw results with the titles and the respective options from the metadata.
+     * @param rawResults
+     * @param metadata
+     */
+    export function digestSingleChoiceResults(rawResults: VotingApi.RawResults, metadata: ProcessMetadata): ProcessResultsSingleChoice {
+        const { results, envelopHeight } = rawResults
+
+        const resultsDigest: ProcessResultsSingleChoice = { totalVotes: envelopHeight, questions: [] }
+        const zippedQuestions = metadata.questions.map((e, i) => ({ meta: e, result: results[i] }))
+        resultsDigest.questions = zippedQuestions.map((zippedEntry, idx): SingleChoiceQuestionResults => {
+            const zippedOptions = zippedEntry.meta.choices.map((e, i) => ({ title: e.title, value: zippedEntry.result[i] }))
+            return {
+                title: zippedEntry.meta.title,
+                voteResults: zippedOptions.map((option) => ({
+                    title: option.title,
+                    votes: BigNumber.from(option.value || 0),
+                })),
+            }
+        })
+        return resultsDigest
     }
 }
 

--- a/src/errors/results.ts
+++ b/src/errors/results.ts
@@ -1,0 +1,5 @@
+export class ResultsNotAvailableError extends Error {
+  constructor(message?: string) {
+    super(message ? message : "The results are not available");
+  }
+}

--- a/src/models/process.ts
+++ b/src/models/process.ts
@@ -138,6 +138,16 @@ export interface SingleChoiceQuestionResults {
     }>,
 }
 
+// Multiple choice
+export interface ProcessResultsSingleQuestion {
+    totalVotes: number,
+    title: MultiLanguage<string>,
+    options: Array<{
+        title: MultiLanguage<string>,
+        votes: BigNumber
+    }>
+}
+
 // Envelope and proofs
 
 export type IProofGraviton = string

--- a/src/models/process.ts
+++ b/src/models/process.ts
@@ -124,17 +124,18 @@ export interface ProcessMetadata {
 export type INewProcessParams = Omit<Omit<IProcessCreateParams, "metadata">, "questionCount"> & { metadata: ProcessMetadata }
 export type INewProcessErc20Params = Omit<Omit<INewProcessParams, "censusRoot">, "censusOrigin">
 
-export interface DigestedProcessResults {
+// Single choice
+export interface ProcessResultsSingleChoice {
     totalVotes: number,
-    questions: DigestedProcessResultItem[],
+    questions: SingleChoiceQuestionResults[],
 }
 
-export interface DigestedProcessResultItem {
+export interface SingleChoiceQuestionResults {
     title: MultiLanguage<string>,
-    voteResults: {
+    voteResults: Array<{
         title: MultiLanguage<string>,
         votes: BigNumber,
-    }[],
+    }>,
 }
 
 // Envelope and proofs

--- a/test/unit/results.ts
+++ b/test/unit/results.ts
@@ -1,0 +1,168 @@
+import "mocha" // using @types/mocha
+import { expect } from "chai"
+import { addCompletionHooks } from "../mocha-hooks"
+
+import { ProcessMetadata, ProcessMetadataTemplate } from "../../src/models/process"
+import { Voting, VotingApi } from "../../src/api/voting"
+import { ProcessStatus } from "dvote-solidity"
+
+addCompletionHooks()
+
+describe("Results", () => {
+  it("Should aggregate single choice results (zip)", () => {
+    // 1
+    const meta: ProcessMetadata = JSON.parse(JSON.stringify(ProcessMetadataTemplate))
+    meta.questions = [
+      {
+        choices: [{ title: { default: "Should be 10" }, value: 0 }, { title: { default: "Should be 20" }, value: 1 }, { title: { default: "Should be 30" }, value: 2 }],
+        title: { default: "Q1" },
+        description: { default: "Desc" }
+      }
+    ]
+    const rawResults: VotingApi.RawResults = {
+      results: [["10", "20", "30"]],
+      status: new ProcessStatus(0),
+      envelopHeight: 1234
+    }
+
+    const digestedResults = Voting.digestSingleChoiceResults(rawResults, meta)
+    expect(digestedResults.totalVotes).to.eq(rawResults.envelopHeight)
+    expect(digestedResults.questions.length).to.eq(1)
+    expect(digestedResults.questions[0].title).to.deep.eq(meta.questions[0].title)
+    expect(digestedResults.questions[0].voteResults.length).to.eq(3)
+    expect(digestedResults.questions[0].voteResults[0].title).to.deep.eq(meta.questions[0].choices[0].title)
+    expect(digestedResults.questions[0].voteResults[0].votes.toString()).to.eq(rawResults.results[0][0])
+    expect(digestedResults.questions[0].voteResults[1].votes.toString()).to.eq(rawResults.results[0][1])
+    expect(digestedResults.questions[0].voteResults[2].votes.toString()).to.eq(rawResults.results[0][2])
+
+    // 2
+    const meta2: ProcessMetadata = JSON.parse(JSON.stringify(ProcessMetadataTemplate))
+    meta2.questions = [
+      {
+        choices: [{ title: { default: "Should be 100" }, value: 0 }, { title: { default: "Should be 200" }, value: 1 }, { title: { default: "Should be 300" }, value: 2 }],
+        title: { default: "Q1" },
+        description: { default: "Desc" }
+      },
+      {
+        choices: [{ title: { default: "Should be 400" }, value: 0 }, { title: { default: "Should be 500" }, value: 1 }, { title: { default: "Should be 600" }, value: 2 }],
+        title: { default: "Q2" },
+        description: { default: "Desc" }
+      }
+    ]
+    const rawResults2: VotingApi.RawResults = {
+      results: [["100", "200", "300"], ["400", "500", "600"]],
+      status: new ProcessStatus(0),
+      envelopHeight: 2345
+    }
+
+    const digestedResults2 = Voting.digestSingleChoiceResults(rawResults2, meta2)
+    expect(digestedResults2.totalVotes).to.eq(rawResults2.envelopHeight)
+    expect(digestedResults2.questions.length).to.eq(2)
+    expect(digestedResults2.questions[0].title).to.deep.eq(meta2.questions[0].title)
+    expect(digestedResults2.questions[0].voteResults.length).to.eq(3)
+    expect(digestedResults2.questions[0].voteResults[0].title).to.deep.eq(meta2.questions[0].choices[0].title)
+    expect(digestedResults2.questions[0].voteResults[0].votes.toString()).to.eq(rawResults2.results[0][0])
+    expect(digestedResults2.questions[0].voteResults[1].votes.toString()).to.eq(rawResults2.results[0][1])
+    expect(digestedResults2.questions[0].voteResults[2].votes.toString()).to.eq(rawResults2.results[0][2])
+
+    expect(digestedResults2.questions[1].title).to.deep.eq(meta2.questions[1].title)
+    expect(digestedResults2.questions[1].voteResults.length).to.eq(3)
+    expect(digestedResults2.questions[1].voteResults[0].title).to.deep.eq(meta2.questions[1].choices[0].title)
+    expect(digestedResults2.questions[1].voteResults[0].votes.toString()).to.eq(rawResults2.results[1][0])
+    expect(digestedResults2.questions[1].voteResults[1].votes.toString()).to.eq(rawResults2.results[1][1])
+    expect(digestedResults2.questions[1].voteResults[2].votes.toString()).to.eq(rawResults2.results[1][2])
+
+  })
+
+  it("Should aggregate single question results (weighted index)", () => {
+    // 1
+    const meta: ProcessMetadata = JSON.parse(JSON.stringify(ProcessMetadataTemplate))
+    meta.questions = [
+      {
+        choices: [{ title: { default: "AA" }, value: 0 }, { title: { default: "BB" }, value: 1 }],
+        title: { default: "Q1" },
+        description: { default: "Desc" }
+      }
+    ]
+    const rawResults: VotingApi.RawResults = {
+      results: [["0", "0", "3"], ["0", "10", "0"]],
+      status: new ProcessStatus(0),
+      envelopHeight: 1234
+    }
+
+    const digestedResults = Voting.digestSingleQuestionResults(rawResults, meta)
+    expect(digestedResults.totalVotes).to.eq(rawResults.envelopHeight)
+    expect(digestedResults.options.length).to.eq(rawResults.results.length)
+    expect(digestedResults.title).to.deep.eq(meta.questions[0].title)
+    expect(digestedResults.options[0].title).to.deep.eq(meta.questions[0].choices[0].title)
+    expect(digestedResults.options[0].votes.toString()).to.eq("6")
+    expect(digestedResults.options[1].title).to.deep.eq(meta.questions[0].choices[1].title)
+    expect(digestedResults.options[1].votes.toString()).to.eq("10")
+
+    // 2
+    const meta2: ProcessMetadata = JSON.parse(JSON.stringify(ProcessMetadataTemplate))
+    meta2.questions = [
+      {
+        choices: [
+          { title: { default: "AAAA" }, value: 0 },
+          { title: { default: "BBBB" }, value: 1 },
+          { title: { default: "CCCC" }, value: 2 },
+          { title: { default: "DDDD" }, value: 3 }
+        ],
+        title: { default: "Q11" },
+        description: { default: "Desc" }
+      }
+    ]
+    const rawResults2: VotingApi.RawResults = {
+      results: [["3", "0", "0"], ["2", "1", "0"], ["0", "0", "3"], ["0", "0", "1000000000000000000000000000000000"]],
+      status: new ProcessStatus(0),
+      envelopHeight: 2345
+    }
+
+    const digestedResults2 = Voting.digestSingleQuestionResults(rawResults2, meta2)
+    expect(digestedResults2.totalVotes).to.eq(rawResults2.envelopHeight)
+    expect(digestedResults2.options.length).to.eq(rawResults2.results.length)
+    expect(digestedResults2.title).to.deep.eq(meta2.questions[0].title)
+    expect(digestedResults2.options[0].title).to.deep.eq(meta2.questions[0].choices[0].title)
+    expect(digestedResults2.options[0].votes.toString()).to.eq("0")
+    expect(digestedResults2.options[1].title).to.deep.eq(meta2.questions[0].choices[1].title)
+    expect(digestedResults2.options[1].votes.toString()).to.eq("1")
+    expect(digestedResults2.options[2].title).to.deep.eq(meta2.questions[0].choices[2].title)
+    expect(digestedResults2.options[2].votes.toString()).to.eq("6")
+    expect(digestedResults2.options[3].title).to.deep.eq(meta2.questions[0].choices[3].title)
+    expect(digestedResults2.options[3].votes.toString()).to.eq("2000000000000000000000000000000000")
+
+    // 3
+    const meta3: ProcessMetadata = JSON.parse(JSON.stringify(ProcessMetadataTemplate))
+    meta3.questions = [
+      {
+        choices: [
+          { title: { default: "AAAAA" }, value: 0 },
+          { title: { default: "BBBBB" }, value: 1 },
+          { title: { default: "CCCCC" }, value: 2 },
+          { title: { default: "DDDDD" }, value: 3 }
+        ],
+        title: { default: "Q111" },
+        description: { default: "Desc" }
+      }
+    ]
+    const rawResults3: VotingApi.RawResults = {
+      results: [["3", "0", "0", "10"], ["10000000", "1000000000000000000000000000000000", "0", "0"], ["0", "0", "5000000000000000000000000000000000"], ["5000", "0", "0", "1"]],
+      status: new ProcessStatus(0),
+      envelopHeight: 3456
+    }
+
+    const digestedResults3 = Voting.digestSingleQuestionResults(rawResults3, meta3)
+    expect(digestedResults3.totalVotes).to.eq(rawResults3.envelopHeight)
+    expect(digestedResults3.options.length).to.eq(rawResults3.results.length)
+    expect(digestedResults3.title).to.deep.eq(meta3.questions[0].title)
+    expect(digestedResults3.options[0].title).to.deep.eq(meta3.questions[0].choices[0].title)
+    expect(digestedResults3.options[0].votes.toString()).to.eq("30")
+    expect(digestedResults3.options[1].title).to.deep.eq(meta3.questions[0].choices[1].title)
+    expect(digestedResults3.options[1].votes.toString()).to.eq("1000000000000000000000000000000000")
+    expect(digestedResults3.options[2].title).to.deep.eq(meta3.questions[0].choices[2].title)
+    expect(digestedResults3.options[2].votes.toString()).to.eq("10000000000000000000000000000000000")
+    expect(digestedResults3.options[3].title).to.deep.eq(meta3.questions[0].choices[3].title)
+    expect(digestedResults3.options[3].votes.toString()).to.eq("3")
+  })
+})


### PR DESCRIPTION
The current PR adds support for aggregating multiple choice results.
- Splitting the previous `getDigestedResults()` into the raw `getResults()` and the aggregators `digestSingleChoiceResults()` `digestSingleQuestionResults()` that the UI can use
- Unit testing has been added to ensure the aggregation correctness