### PR TITLE
Fix naming in anonymous voting requests and filenames

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -37,7 +37,7 @@ export const CENSUS_MAX_BULK_SIZE = 400 // # of claims per addClaimBulk request
 export const GATEWAY_SELECTION_TIMEOUT = 4000  // milliseconds
 
 export const ZK_VOTING_CIRCUIT_WASM_FILE_NAME = "circuit.wasm"
-export const ZK_VOTING_ZKEY_FILE_NAME = "circuit_final.zkey"
+export const ZK_VOTING_ZKEY_FILE_NAME = "circuit.zkey"
 export const ZK_VOTING_VERIFICATION_KEY_FILE_NAME = "verification_key.json"
 
 // Const Values for Avax and Fuji
@@ -49,7 +49,7 @@ export declare const AVAX_FUJI_PROVIDER = "https://api.avax-test.network/ext/bc/
 export declare const AVAX_PROVIDER = "https://api.avax-test.network/ext/bc/C/rpc"
 export declare const AVAX_GAS_PRICE: BigNumber;
 export declare const AVAX_FUJI_ENS_REGISTRY_ADDRESS = "0x21a60F4a895769bE78436CC0D83956db83A4297c"
-export declare const AVAX_ENS_REGISTRY_ADDRESS = "" // not yet next round 
+export declare const AVAX_ENS_REGISTRY_ADDRESS = "" // not yet next round
 
 
 /**

--- a/packages/voting/src/voting-calls.ts
+++ b/packages/voting/src/voting-calls.ts
@@ -199,7 +199,7 @@ export namespace VotingApi {
 
                 return {
                     index: response.circuitIndex || 0,
-                    uri: response.circuitConfig.url,
+                    uri: response.circuitConfig.uri,
                     circuitPath: response.circuitConfig.circuitPath,
                     maxSize: response.circuitConfig.parameters[0],
                     witnessHash: "0x" + Buffer.from(response.circuitConfig.witnessHash, "base64").toString("hex"),


### PR DESCRIPTION
Fixed `ZK_VOTING_ZKEY_FILE_NAME` and `getProcessCircuitConfig` response due to https://github.com/vocdoni/vocdoni-node/pull/376/files