### PR TITLE
`JsonSignature.sort` minor change

### DIFF
--- a/packages/signing/CHANGELOG.md
+++ b/packages/signing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @vocdoni/signing - Changelog
 
+## 1.16.2
+
+- `JsonSignature.sort` changed for accepting `undefined` values
+
 ## 1.16.1
 
 - `JsonSignature.sort` now returns the same type as the input parameter, not `JsonLike`

--- a/packages/signing/package.json
+++ b/packages/signing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vocdoni/signing",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "JavaScript/TypeScript signing package",
   "main": "dist/index",
   "types": "dist/index",
@@ -27,7 +27,8 @@
     "@ethersproject/providers": "^5.5.0",
     "@ethersproject/signing-key": "^5.5.0",
     "@ethersproject/transactions": "^5.5.0",
-    "@ethersproject/wallet": "^5.5.0"
+    "@ethersproject/wallet": "^5.5.0",
+    "@vocdoni/common": "^1.15.3"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/signing/src/json-signature.ts
+++ b/packages/signing/src/json-signature.ts
@@ -123,8 +123,8 @@ export namespace JsonSignature {
             case "bigint":
             case "function":
             case "symbol":
-            case "undefined":
                 throw new Error("JSON objects with " + typeof data + " values are not supported")
+            case "undefined":
             case "boolean":
             case "number":
             case "string":


### PR DESCRIPTION
`JsonSignature.sort` changed for accepting `undefined` values