### PR TITLE
Added 'build-all.sh' script for easy development usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "npm run build",
     "clean": "rimraf dist",
     "prebuild": "git submodule init && git submodule update",
-    "build": "npm run clean && tsc",
+    "build": "./scripts/build-all.sh",
     "watch": "tsc -w -p .",
     "test": "./scripts/test-all.sh"
   },

--- a/packages/voting/package.json
+++ b/packages/voting/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "clean": "rimraf dist",
+    "clean": "rimraf ./dist",
     "build": "npm run clean && tsc",
     "watch": "tsc -w -p .",
     "test": "npm run build && mocha -r ts-node/register test/**/*.ts"

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+CYAN="\e[36m"
+ENDCOLOR="\e[0m"
+
+# Add here any packages to be built (in order, otherwise will fail due to missing dependencies)
+PRE_BUILD_PACKAGES_ORDERED=(
+    'common'
+    'contract-wrappers'
+    'encryption'
+    'signing'
+    'hashing'
+    'data-models'
+    'client'
+    'census'
+    'voting'
+    'wallets'
+)
+
+function print_task {
+    echo -e $CYAN $1 $ENDCOLOR
+}
+
+function install_deps {
+    print_task ": Installing packages"
+    npm install
+}
+
+function build_all {
+    print_task ": Building subpackages"
+    for d in ${PRE_BUILD_PACKAGES_ORDERED[@]}
+    do
+        print_task ":: Building @vocdoni/$d"
+        npm run build -w ./packages/$d
+    done
+
+    # build main repo too
+    npm run clean
+    tsc -b
+}
+
+install_deps
+build_all

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -2,40 +2,17 @@
 
 set -e
 
-PRE_BUILD_PACKAGES_ORDERED=('common' 'contract-wrappers' 'encryption' 'signing' 'hashing' 'data-models')
-PACKAGES=$(find ./packages -type d -maxdepth 1 -mindepth 1)
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
-###############################################################################
-
-function install_deps {
-  echo "Installing packages"
-  npm install
-}
-
-function build_all {
-  echo "Building subpackages"
-  for d in ${PRE_BUILD_PACKAGES_ORDERED[@]}
-  do
-    echo "Prebuilding $d"
-    cd ./packages/$d
-    npm run build
-    cd -
-  done
-}
+source $SCRIPT_DIR/build-all.sh
 
 function test_all {
-  echo "Testing subpackages"
-  for d in $PACKAGES
-  do
-    echo "Testing $d"
-    cd $d
-    npm run test
-    cd -
-  done
+    print_task ": Testing subpackages"
+    for d in ${PRE_BUILD_PACKAGES_ORDERED[@]}
+    do
+        echo ":: Testing @vocdoni/$d"
+        npm run test -w ./packages/$d
+    done
 }
 
-###############################################################################
-
-install_deps
-build_all
 test_all


### PR DESCRIPTION
Created `build-all.sh` script based on the `test-all.sh` existing one. Now using `npm run build` from the root folder of dvote-js will run the builds in order, ensuring there are no dependency issues.

All the packages being built in order are listed in this new `build-all.sh` script, which is then used by `test-all.sh`. If you need to add new packages which will be dependencies of other packages, you have to add them in the expected order in this new file.

Note that using npm workspaces, you can run any package script from dvote-js root folder using `-w` param:

~~~bash
npm run build -w packages/common
~~~

What does not work out of the box is using the "build all workspaces" feature, because it tries to do so by alphabetical order, breaking the dependency order.

Edit: I also fixed an issue with the `find` command in the script. The specified params weren't in the correct order (this removes an annoying notice in the console).