### PR TITLE
BytesSignature, JSONSignature: hopefully better method documentation

### DIFF
--- a/packages/signing/src/bytes-signature.ts
+++ b/packages/signing/src/bytes-signature.ts
@@ -6,9 +6,8 @@ export namespace BytesSignature {
     // MESSAGES
 
     /**
-     * Prefix and Sign a binary payload using the given Ethers wallet or signer.
+     * Signs a message after adding the prefix "Vocdoni signed message\n".
      * @param messageBytes
-     * @param chainId The ID of the Vocdoni blockchain deployment for which the message is intended to
      * @param walletOrSigner
      */
     export function signMessage(messageBytes: Uint8Array, walletOrSigner: Wallet | Signer): Promise<string> {
@@ -19,7 +18,7 @@ export namespace BytesSignature {
     }
 
     /**
-     * Checks whether the given public key signed the given message
+     * Checks whether the given public key signed the given Vocdoni-prefixed message
      * @param signature Hex encoded signature (created with the Ethereum prefix)
      * @param publicKey
      * @param messageBytes Uint8Array of the message
@@ -33,7 +32,7 @@ export namespace BytesSignature {
     }
 
     /**
-     * Returns the public key that signed the given message
+     * Returns the public key that signed the given Vocdoni-prefixed message
      *
      * @param messageBytes The payload being signed
      * @param signature Hex encoded signature (created with the Ethereum prefix)
@@ -51,7 +50,7 @@ export namespace BytesSignature {
     // TRANSACTIONS
 
     /**
-     * Prefix and Sign a binary payload using the given Ethers wallet or signer.
+     * Sign a binary payload with the "Vocdoni signed transaction:\nchainID\n" prefix
      * @param messageBytes
      * @param chainId The ID of the Vocdoni blockchain deployment for which the message is intended to
      * @param walletOrSigner
@@ -64,7 +63,7 @@ export namespace BytesSignature {
     }
 
     /**
-     * Checks whether the given public key signed the given transaction
+     * Checks whether the given public key signed the given Vocdoni-prefixed transaction
      * @param signature Hex encoded signature (created with the Ethereum prefix)
      * @param publicKey
      * @param messageBytes Uint8Array of the message
@@ -79,7 +78,7 @@ export namespace BytesSignature {
     }
 
     /**
-     * Returns the public key that signed the given transaction
+     * Returns the public key that signed the given Vocdoni-prefixed transaction
      *
      * @param messageBytes The payload being signed
      * @param signature Hex encoded signature (created with the Ethereum prefix)

--- a/packages/signing/src/json-signature.ts
+++ b/packages/signing/src/json-signature.ts
@@ -8,8 +8,9 @@ export namespace JsonSignature {
     // MESSAGES
 
     /**
-     * Sign a JSON message using the given Ethers wallet or signer.
-     * Ensures that the object keys are alphabetically sorted.
+     * Sign a JSON message with using the given Ethers wallet or signer. Ensures
+     * that the object keys are alphabetically sorted, then prefixes "Vocdoni
+     * signed message:\n" to the message before signing.
      * @param message JSON object of the `response` or `error` fields
      * @param walletOrSigner
      */
@@ -23,7 +24,7 @@ export namespace JsonSignature {
     }
 
     /**
-     * Checks whether the given public key signed the given JSON message with its fields
+     * Checks whether the given public key signed the given Vocdoni-prefixed JSON message with its fields
      * sorted alphabetically
      * @param message JSON object of the `response` or `error` fields
      * @param signature Hex encoded signature (created with the Ethereum prefix)
@@ -40,7 +41,7 @@ export namespace JsonSignature {
     }
 
     /**
-     * Returns the public key that signed the given JSON message, having its fields sorted alphabetically
+     * Returns the public key that signed the given Vocdoni-prefixed JSON message, having its fields sorted alphabetically
      *
      * @param message JSON object of the `response` or `error` fields
      * @param signature Hex encoded signature (created with the Ethereum prefix)
@@ -59,8 +60,9 @@ export namespace JsonSignature {
     // TRANSACTIONS
 
     /**
-     * Sign a JSON transaction using the given Ethers wallet or signer.
-     * Ensures that the object keys are alphabetically sorted.
+     * Sign a JSON transaction using the given Ethers wallet or signer. Ensures
+     * that the object keys are alphabetically sorted,  then prefixes "Vocdoni
+     * signed transaction:\nchainID\n" before signing.
      * @param message JSON object
      * @param walletOrSigner
      */
@@ -74,7 +76,7 @@ export namespace JsonSignature {
     }
 
     /**
-     * Checks whether the given public key signed the given JSON transaction with its fields
+     * Checks whether the given public key signed the given Vocdoni-prefixed JSON transaction with its fields
      * sorted alphabetically
      * @param message JSON object
      * @param signature Hex encoded signature (created with the Ethereum prefix)
@@ -91,7 +93,7 @@ export namespace JsonSignature {
     }
 
     /**
-     * Returns the public key that signed the given JSON transaction, having its fields sorted alphabetically
+     * Returns the public key that signed the given Vocdoni-prefixed JSON transaction, having its fields sorted alphabetically
      *
      * @param message JSON object
      * @param signature Hex encoded signature (created with the Ethereum prefix)


### PR DESCRIPTION
BytesSignature.signMessage() has no chainId param, method documentation should reflect that

BytesSignature method documentation gives a hint as to how the message/transaction is handled before it is signed